### PR TITLE
Restrict supported websocket client versions #262

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ urllib3>=1.19.1,!=1.21  # MIT
 pyyaml>=3.12  # MIT
 oauth2client>=4.0.0  # Apache-2.0
 ipaddress>=1.0.17  # PSF
-websocket-client>=0.32.0 # LGPLv2+
+websocket-client>=0.32.0,!=0.41.*,!=0.42.* # LGPLv2+


### PR DESCRIPTION
There are a couple versions which won't work with this library,
specifically 0.41.1 - 0.42.0

Those versions prevent the kube CA certificate from being propagated to
python's SSL Context, which results in a CERTIFICATE_VERIFY_FAILED error
being raised when a user tries to stream logs from a Pod using the
kubernetes python library.

This change explicitly blacklists the problematic range of bad websocket
client library versions, so that users don't experience odd failures if
they happen to have the affected versions installed when they install
this project's library.

The restriction should provide the least amount of forced dependecy
updates, affecting only those that would have been affected by the bug.

Bug appeared in 0.41.1: https://goo.gl/cxSrXt
Was fixed in 0.43.0: https://goo.gl/EmJcF8