### PR TITLE
V1OwnerReference.md: s/api_version/apiVersion/g

### DIFF
--- a/kubernetes/docs/V1OwnerReference.md
+++ b/kubernetes/docs/V1OwnerReference.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**api_version** | **str** | API version of the referent. | 
+**apiVersion** | **str** | API version of the referent. | 
 **block_owner_deletion** | **bool** | If true, AND if the owner has the \&quot;foregroundDeletion\&quot; finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \&quot;delete\&quot; permission of the owner, otherwise 422 (Unprocessable Entity) will be returned. | [optional] 
 **controller** | **bool** | If true, this reference points to the managing controller. | [optional] 
 **kind** | **str** | Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds | 


### PR DESCRIPTION
The documentation has the wrong key. While implementing test cases for my own CRDs, I got the following error:

```
kubernetes.client.rest.ApiException: (422)
Reason: Unprocessable Entity
HTTP response headers: HTTPHeaderDict({
     'Content-Type': 'application/json', 'Date': 'Tue, 20 Mar 2018 02:16:20 GMT', 
      'Content-Length': '482'})
HTTP response body: {"kind":"Status","apiVersion":"v1",
    "metadata":{},"status":"Failure",
    "message":"AppBuild.paas.intuit.com \"appbuild-6b6db70\" is invalid: 
           metadata.ownerReferences.apiVersion: Invalid value: \"\": version must not 
           be empty","reason":"Invalid",
    "details":{"name":"appbuild-6b6db70","group":"paas.intuit.com","kind":"AppBuild",
    "causes":[{"reason":"FieldValueInvalid","message":"Invalid value: \"\": version must 
           not be empty","field":"metadata.ownerReferences.apiVersion"}]},"code":422}
```

# Is api correct?

Other potential areas for changing are:

* https://github.com/kubernetes-client/python/blob/369366a813964e3d72e91d402c5f471275e7a3e5/kubernetes/client/models/v1_owner_reference.py#L34