### PR TITLE
binary websocket support, plus examples

### DIFF
--- a/examples/exec.py
+++ b/examples/exec.py
@@ -109,7 +109,7 @@ resp = stream(api.connect_get_namespaced_pod_exec, name, 'default',
               binary=True,
               _preload_content=False)
 
-source_file = '/tmp/dash'
+source_file = '/bin/sh'
 
 with TemporaryFile() as tar_buffer:
     with tarfile.open(fileobj=tar_buffer, mode='w') as tar:

--- a/kubernetes/client/apis/core_v1_api.py
+++ b/kubernetes/client/apis/core_v1_api.py
@@ -21,6 +21,7 @@ import re
 from six import iteritems
 
 from ..api_client import ApiClient
+import six
 
 
 class CoreV1Api(object):
@@ -926,7 +927,7 @@ class CoreV1Api(object):
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,
-                                        response_type='str',
+                                        response_type=six.binary_type,
                                         auth_settings=auth_settings,
                                         async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),

--- a/tox.ini
+++ b/tox.ini
@@ -23,16 +23,19 @@ commands =
 commands =
    python -V
    {toxinidir}/scripts/kube-init.sh py.test -vvv -s []
+   {toxinidir}/scripts/kube-init.sh python examples/exec.py
 
 [testenv:py35-functional]
 commands =
    python -V
    {toxinidir}/scripts/kube-init.sh py.test -vvv -s []
+   {toxinidir}/scripts/kube-init.sh python examples/exec.py
 
 [testenv:py36-functional]
 commands =
    python -V
    {toxinidir}/scripts/kube-init.sh py.test -vvv -s []
+   {toxinidir}/scripts/kube-init.sh python examples/exec.py
 
 [testenv:coverage]
 commands =


### PR DESCRIPTION
Hello, in #476 we noted that we currently cannot stream binary data to/from pods so no feature like `kubectl cp` (and probably others) could be implemented.

I've worked on that, two PR came out. The first is kubernetes-client/python-base#52 and when it will be merged, this one will then unlock binary streams and provide couple examples on how to do it.

Problem: I had to patch core_v1_api.py swagger generated code, as swagger itself seems to ignore [binary type](https://github.com/kubernetes/kubernetes/compare/master...aogier:feature/binary-type) specification. I'm currently investigating on that.  
In the meanwhile I could produce a temporary patch in `scripts/` and apply it when `client-update`ing but I'd like to know what do you think about that part.

Thank you, ciao

