### PR TITLE
Only depend on ipaddress in python2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ setuptools>=21.0.0  # PSF/ZPL
 urllib3>=1.19.1,!=1.21  # MIT
 pyyaml>=3.12  # MIT
 google-auth>=1.0.1  # Apache-2.0
-ipaddress>=1.0.17  # PSF
+ipaddress>=1.0.17;python_version=="2.7"  # PSF
 websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.* # LGPLv2+
 requests # Apache-2.0
 requests-oauthlib # ISC

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 # Do not edit these constants. They will be updated automatically
 # by scripts/update-client.sh.
@@ -27,8 +27,18 @@ DEVELOPMENT_STATUS = "4 - Beta"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
+EXTRAS = {}
+REQUIRES = []
 with open('requirements.txt') as f:
-    REQUIRES = f.readlines()
+    for line in f:
+        line, _, _ = line.partition('#')
+        line = line.strip()
+        if ';' in line:
+            requirement, _, specifier = line.partition(';')
+            for_specifier = EXTRAS.setdefault(':{}'.format(specifier), [])
+            for_specifier.append(requirement)
+        else:
+            REQUIRES.append(line)
 
 with open('test-requirements.txt') as f:
     TESTS_REQUIRES = f.readlines()
@@ -44,6 +54,7 @@ setup(
     keywords=["Swagger", "OpenAPI", "Kubernetes"],
     install_requires=REQUIRES,
     tests_require=TESTS_REQUIRES,
+    extras_require=EXTRAS,
     packages=['kubernetes', 'kubernetes.client', 'kubernetes.config',
               'kubernetes.watch', 'kubernetes.client.apis',
               'kubernetes.stream', 'kubernetes.client.models'],


### PR DESCRIPTION
The ipaddress module became a standard module in python3.3.

This uses [environment markers][pep508] to only select the `ipaddress` module
in python2.7.  In setuptools, the most compatible way to accomplish this is
through the `extras_require` field (as suggested in the [wheel][wheel] docs).

[pep508]: https://www.python.org/dev/peps/pep-0508/#id23
[wheel]: https://wheel.readthedocs.io/en/latest/#defining-conditional-dependencies