### PR TITLE
Update python-base, CHANGELOG and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v7.0.0
+**New Features:**
+- Add support for refreshing Azure tokens [kubernetes-client/python-base#77](https://github.com/kubernetes-client/python-base/pull/77)
+
 # v7.0.0b1
 **New Features:**
 - Add Azure support to authentication loading [kubernetes-client/python-base#74](https://github.com/kubernetes-client/python-base/pull/74)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ between client-python versions.
 | 5.0            | Kubernetes main repo, 1.9 branch     | ✓                             |
 | 6.0 Alpha/Beta | Kubernetes main repo, 1.10 branch    | ✗                             |
 | 6.0            | Kubernetes main repo, 1.10 branch    | ✓                             |
-| 7.0 Alpha/Beta | Kubernetes main repo, 1.11 branch    | ✓                             |
+| 7.0 Alpha/Beta | Kubernetes main repo, 1.11 branch    | ✗                             |
+| 7.0            | Kubernetes main repo, 1.11 branch    | ✓                             |
 
 
 Key:


### PR DESCRIPTION
pick up python-base change: Add support for refreshing Azure tokens.
update CHANGELOG and README to prepare for 7.0.0 release.

/cc @yliaog 
Please take a look. Thanks!