### PR TITLE
Revert CHANGELOG to exclude api change from GA release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 **New Features:**
 - Add support for refreshing Azure tokens [kubernetes-client/python-base#77](https://github.com/kubernetes-client/python-base/pull/77)
 
-**New API:**
-- Add custom object status and scale api [kubernetes-client/gen#72](https://github.com/kubernetes-client/gen/pull/72)
-
 # v7.0.0b1
 **New Features:**
 - Add Azure support to authentication loading [kubernetes-client/python-base#74](https://github.com/kubernetes-client/python-base/pull/74)


### PR DESCRIPTION
After a discussion with @yliaog, we want to keep the changes between beta release and GA release minimum (I'll update devel documentation about the release procedure). We decided to not include this new API change in v7.0.0.

The [spec can be fixed](https://github.com/kubernetes-client/gen/pull/72#pullrequestreview-146260670) and we can introduce the API to v8.

Note that we kept the generated new API in [master branch](https://github.com/kubernetes-client/python/pull/594/commits/17db994abc5bc2a40b0d0ea108c4cc3c0db8c3a9). People can give it a try and report issues [here](https://github.com/kubernetes-client/python/issues)

/cc @yliaog 