### PR TITLE
Update python-base submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v8.0.0b1
+**Bug Fix:**
+- Update ExecProvider to use safe\_get() to tolerate kube-config file that sets
+  `args: null` and `env: null` [kubernetes-client/python-base#91](https://github.com/kubernetes-client/python-base/pull/91)
+
 # v8.0.0a1
 **New Feature:**
 - Add exec-plugins support in kubeconfig [kubernetes-client/python-base#75](https://github.com/kubernetes-client/python-base/pull/75)


### PR DESCRIPTION
to pick up changes:
- Replace encodestring and decodestring for standard_b64encode and standard_b64decode (https://github.com/kubernetes-client/python-base/pull/90)
- Update ExecProvider to use safe_get(); Update unit tests to use ConfigNode() instead of dict() (https://github.com/kubernetes-client/python-base/pull/91)

And update CHANGELOG to mention user-facing changes (README doesn't need to be changed from 8.0.0a1 to 8.0.0b1)

... in preparation for 8.0.0b1 release. The next step is to merge master branch onto release-8.0 branch and re-generate the client. 

/assign @yliaog 
Thanks for reviewing :)