### PR TITLE
[WIP] Update localkube version to 1.9.4 in Travis CI

### DIFF
--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -55,7 +55,7 @@ sudo chmod +x kubectl
 sudo mv kubectl /usr/local/bin/
 
 echo "Download localkube from minikube project"
-wget -O localkube "https://storage.googleapis.com/minikube/k8sReleases/v1.7.0/localkube-linux-amd64"
+wget -O localkube "https://storage.googleapis.com/minikube/k8sReleases/v1.9.4/localkube-linux-amd64"
 sudo chmod +x localkube
 sudo mv localkube /usr/local/bin/
 

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -55,7 +55,7 @@ sudo chmod +x kubectl
 sudo mv kubectl /usr/local/bin/
 
 echo "Download localkube from minikube project"
-wget -O localkube "https://storage.googleapis.com/minikube/k8sReleases/v1.9.0/localkube-linux-amd64"
+wget -O localkube "https://storage.googleapis.com/minikube/k8sReleases/v1.8.0/localkube-linux-amd64"
 sudo chmod +x localkube
 sudo mv localkube /usr/local/bin/
 

--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -55,7 +55,7 @@ sudo chmod +x kubectl
 sudo mv kubectl /usr/local/bin/
 
 echo "Download localkube from minikube project"
-wget -O localkube "https://storage.googleapis.com/minikube/k8sReleases/v1.9.4/localkube-linux-amd64"
+wget -O localkube "https://storage.googleapis.com/minikube/k8sReleases/v1.9.0/localkube-linux-amd64"
 sudo chmod +x localkube
 sudo mv localkube /usr/local/bin/
 


### PR DESCRIPTION
This PR addresses #660.
Update localkube version to 1.9.4 so that we could use app/v1beta2 and app/v1 in Travis CI.