### PR TITLE
Update Travis CI to use most current k8s server version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # ref: https://docs.travis-ci.com/user/languages/python
 language: python
-dist: trusty
+dist: xenial
 sudo: true
 services:
   - docker


### PR DESCRIPTION
This PR corrects behavior reported in #660 that causes e2e tests which uses API introduced after 1.7.0 to fail.

Changes:
- switch local k8s cluster from depreciated localkube to minikube (https://github.com/redspread/localkube)
- upgrade server version to most current release
- Raised Linux build platform from 14.04 to 16.04 (14.04 only supports running minikube with localkube, restricting highest version to 1.10) https://kubernetes.io/docs/setup/independent/install-kubeadm/
- Mount / to avoid dns issues (https://github.com/LiliC/travis-minikube/blob/minikube-30-kube-1.12/.travis.yml)

/assign @roycaihw 