### PR TITLE
change pep8 into pycodestyle since pep8 is depreciated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
      - python: 2.7
        env: TOXENV=py27-functional
      - python: 2.7
-       env: TOXENV=update-pep8
+       env: TOXENV=update-pycodestyle
      - python: 2.7
        env: TOXENV=docs
      - python: 2.7

--- a/scripts/update-pycodestyle.sh
+++ b/scripts/update-pycodestyle.sh
@@ -49,7 +49,7 @@ if [[ -z ${ENV} ]]; then
     trap "deactivate" EXIT SIGINT
 
     echo "--- Updating tools"
-    pip install --upgrade pep8
+    pip install --upgrade pycodestyle
     pip install --upgrade autopep8
     pip install --upgrade isort
 fi
@@ -70,10 +70,10 @@ for SOURCE in $SOURCES; do
     isort -y $SOURCE
 done
 
-echo "--- check pep8 (all need to be fixed manually)"
+echo "--- check pycodestyle (all need to be fixed manually)"
 set +o errexit
 for SOURCE in $SOURCES; do
-    pep8 $SOURCE
+    pycodestyle $SOURCE
 done
 
 if [[ ! -z ${ENV} ]]; then

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,6 +8,6 @@ mock>=2.0.0
 sphinx>=1.2.1,!=1.3b1,<1.4 # BSD
 recommonmark
 codecov>=1.4.0
-pep8
+pycodestyle
 autopep8
 isort

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,9 @@ commands =
 commands =
    python setup.py build_sphinx
 
-[testenv:update-pep8]
+[testenv:update-pycodestyle]
 commands =
-   {toxinidir}/scripts/update-pep8.sh
+   {toxinidir}/scripts/update-pycodestyle.sh
 
 [testenv:py27-functional]
 commands =


### PR DESCRIPTION
This PR fixes #666 - pep8 package has changed its name to pycodestyle.
This PR will come along with another PR from kubernetes/base.