### PR TITLE
Update python-base submodule, README and CHANGELOG for 8.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.0.0
+**New Feature:**
+- Add utility to create API resource from yaml file [kubernetes-client/python#655](https://github.com/kubernetes-client/python/pull/655)
+
 # v8.0.0b1
 **Bug Fix:**
 - Update ExecProvider to use safe\_get() to tolerate kube-config file that sets

--- a/README.md
+++ b/README.md
@@ -118,12 +118,13 @@ between client-python versions.
 | 4.0 Alpha/Beta | Kubernetes main repo, 1.8 branch     | ✗                             |
 | 4.0            | Kubernetes main repo, 1.8 branch     | ✗                             |
 | 5.0 Alpha/Beta | Kubernetes main repo, 1.9 branch     | ✗                             |
-| 5.0            | Kubernetes main repo, 1.9 branch     | ✓                             |
+| 5.0            | Kubernetes main repo, 1.9 branch     | ✗                             |
 | 6.0 Alpha/Beta | Kubernetes main repo, 1.10 branch    | ✗                             |
 | 6.0            | Kubernetes main repo, 1.10 branch    | ✓                             |
 | 7.0 Alpha/Beta | Kubernetes main repo, 1.11 branch    | ✗                             |
 | 7.0            | Kubernetes main repo, 1.11 branch    | ✓                             |
-| 8.0 Alpha/Beta | Kubernetes main repo, 1.12 branch    | ✓                             |
+| 8.0 Alpha/Beta | Kubernetes main repo, 1.12 branch    | ✗                             |
+| 8.0            | Kubernetes main repo, 1.12 branch    | ✓                             |
 
 
 Key:


### PR DESCRIPTION
- python-base: use pycodestyle as pep8 has been deprecated (renamed)
- README: update support matrix
- CHANGELOG: add new feature to changelog

Sanity checked that there is no API change from OpenAPI spec to be committed to master branch. The next step is to rebase release-8.0 branch on master, regenerate client (should be only version constants change), and send a PR against release-8.0 branch.

/assign @yliaog 