### PR TITLE
Support Python 3.7 for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ matrix:
        env: TOXENV=py36
      - python: 3.6
        env: TOXENV=py36-functional
+     - python: 3.7
+       env: TOXENV=py37
+     - python: 3.7
+       env: TOXENV=py37-functional
 
 install:
   - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -77,5 +77,6 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, py37
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*
@@ -30,6 +30,11 @@ commands =
    {toxinidir}/scripts/kube-init.sh py.test -vvv -s []
 
 [testenv:py36-functional]
+commands =
+   python -V
+   {toxinidir}/scripts/kube-init.sh py.test -vvv -s []
+
+[testenv:py37-functional]
 commands =
    python -V
    {toxinidir}/scripts/kube-init.sh py.test -vvv -s []


### PR DESCRIPTION
This PR prepares for a Python 3.7 support from Travis CI.
Edit:
Travis CI do support Python 3.7 now. It requires OpenSSL 1.0.2+ and Ubuntu 16.04+
and luckily we switched to the platform on our Travis CI update...
See https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905