### PR TITLE
Potential security fix CVE-2018-20060

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi>=14.05.14 # MPL
 six>=1.9.0  # MIT
 python-dateutil>=2.5.3  # BSD
 setuptools>=21.0.0  # PSF/ZPL
-urllib3>=1.19.1,!=1.21  # MIT
+urllib3>=1.23  # MIT
 pyyaml>=3.12  # MIT
 google-auth>=1.0.1  # Apache-2.0
 ipaddress>=1.0.17;python_version=="2.7"  # PSF


### PR DESCRIPTION
Security fix for CVE-2018-20060. We need to cherry pick this into at least two previous releases.