### PR TITLE
Release 7.0.1: security fix for CVE-2018-20060

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v7.0.1
+**Security Fix:**
+- Bump urllib3 version to pick up security fix for CVE-2018-20060 [kubernetes-client/python#707](https://github.com/kubernetes-client/python/pull/707)
+
 # v7.0.0
 **New Features:**
 - Add support for refreshing Azure tokens [kubernetes-client/python-base#77](https://github.com/kubernetes-client/python-base/pull/77)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi>=14.05.14 # MPL
 six>=1.9.0  # MIT
 python-dateutil>=2.5.3  # BSD
 setuptools>=21.0.0  # PSF/ZPL
-urllib3>=1.19.1,!=1.21  # MIT
+urllib3>=1.23  # MIT
 pyyaml>=3.12  # MIT
 google-auth>=1.0.1  # Apache-2.0
 ipaddress>=1.0.17;python_version=="2.7"  # PSF


### PR DESCRIPTION
Ref: https://github.com/kubernetes-client/python/pull/707

This release only contains version change for urllib3 dependency. No API change was generated to keep the diff minimum. 

Similar patches are applied to release-8.0 branch ([8.0.1 release](https://github.com/kubernetes-client/python/pull/699)) and [master branch](https://github.com/kubernetes-client/python/pull/707) ([for future 9.0.0a1 release](https://github.com/kubernetes-client/python/pull/698)). 

Next steps are to publish distribution packages to pypi and create github release page.

/assign @yliaog  