### PR TITLE
Manual cherrypick master branch changes to release-9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v9.0.0b1
+**Breaking Change:**
+- Move dependancy adal under extra require [kubernetes-client/python-base#108](https://github.com/kubernetes-client/python-base/pull/108)
+
+**Bug Fix:**
+- Honor the specified resource version in stream request when watch restarts [kubernetes-client/python-base#109](https://github.com/kubernetes-client/python-base/pull/109)
+
+**API Change:**
+- Add timeoutSeconds parameter to CustomObjectsApi list/watch calls [kubernetes-client/gen#94](https://github.com/kubernetes-client/gen/pull/94)
+
+**New Feature:**
+- Avoid creating unused ThreadPools [kubernetes-client/gen#91](https://github.com/kubernetes-client/gen/pull/91)
+
 # v9.0.0a1
 **New Feature:**
 - Avoid creating unused ThreadPools [kubernetes-client/gen#91](https://github.com/kubernetes-client/gen/pull/91)

--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
 approvers:
   - mbohlool
   - caesarxuchao

--- a/examples/create_deployment.py
+++ b/examples/create_deployment.py
@@ -26,7 +26,7 @@ def main():
     config.load_kube_config()
 
     with open(path.join(path.dirname(__file__), "nginx-deployment.yaml")) as f:
-        dep = yaml.load(f)
+        dep = yaml.safe_load(f)
         k8s_beta = client.ExtensionsV1beta1Api()
         resp = k8s_beta.create_namespaced_deployment(
             body=dep, namespace="default")

--- a/kubernetes/e2e_test/test_extensions.py
+++ b/kubernetes/e2e_test/test_extensions.py
@@ -50,7 +50,7 @@ spec:
         - containerPort: 80
 '''
         resp = api.create_namespaced_deployment(
-            body=yaml.load(deployment % name),
+            body=yaml.safe_load(deployment % name),
             namespace="default")
         resp = api.read_namespaced_deployment(name, 'default')
         self.assertIsNotNone(resp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ ipaddress>=1.0.17;python_version=="2.7"  # PSF
 websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.* # LGPLv2+
 requests # Apache-2.0
 requests-oauthlib # ISC
-adal>=1.0.2 # MIT

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ DEVELOPMENT_STATUS = "4 - Beta"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-EXTRAS = {}
+EXTRAS = {
+    'adal': ['adal>=1.0.2']
+}
 REQUIRES = []
 with open('requirements.txt') as f:
     for line in f:


### PR DESCRIPTION
changes in master branch got dropped by `git pull -s ours` when we merge master branch into release-9.0: https://github.com/kubernetes-client/python/pull/751

basically the 14th commit (`"Merge branch 'master' of github.com:kubernetes-client/python into re"`) in https://github.com/kubernetes-client/python/pull/751/commits is empty, which means the 1~13 commits didn't get into release-9.0

this PR manually cherrypicked the 1~13 commits from https://github.com/kubernetes-client/python/pull/751/commits into release-9.0 branch to make sure the changes will be included in 9.0.0b1

 - (ignored five merge commits from robot and squashed four of my commits into one "update base submodule", so there are only five commits in this PR)

double checked the version constants and ran the script to re-generate the client. confirmed that nothing changes