### PR TITLE
Fixes Setup.py error on Windows #676

### DIFF
--- a/scripts/windows-setup-fix.bat
+++ b/scripts/windows-setup-fix.bat
@@ -1,0 +1,10 @@
+REM Install python client in Windows.
+REM Windows doesn't have symbolic link that this repo uses.
+REM This batch script provides a workaround for symbolic link by copying the folders over.
+
+ (	python --version>nul 2>&1 && (
+	echo "Python environment found."
+	)
+	python --version
+	copy ..\kubernetes\base\* ..\kubernetes\
+	cd .. && python setup.py install )


### PR DESCRIPTION
Initial CommitFixes Setup.py error on Windows, added shell script to check python environment, prints the python version, copy files from /kubernetes/base to /kubernetes/ and finally runs python setup.py install issue #676 