### PR TITLE
Adding proxy headers options for configurations. 

### DIFF
--- a/kubernetes/client/configuration.py
+++ b/kubernetes/client/configuration.py
@@ -101,6 +101,8 @@ class Configuration(with_metaclass(TypeWithDefault, object)):
 
         # Proxy URL
         self.proxy = None
+        # Proxy Headers
+        self.proxy_headers = None
         # Safe chars for path_param
         self.safe_chars_for_path_param = ''
 

--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -96,6 +96,7 @@ class RESTClientObject(object):
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
+                proxy_headers=configuration.proxy_headers,
                 **addition_pool_args
             )
         else:


### PR DESCRIPTION
This PR addresses https://github.com/kubernetes-client/python/issues/735

Added options to pass proxy headers in Configuration objects and then pass it to proxy_manager in RESTClientObject.

