### PR TITLE
Adding option to send number of retries to override default value of 3. 

### DIFF
--- a/kubernetes/client/configuration.py
+++ b/kubernetes/client/configuration.py
@@ -105,7 +105,7 @@ class Configuration(with_metaclass(TypeWithDefault, object)):
         self.proxy_headers = None
         # Safe chars for path_param
         self.safe_chars_for_path_param = ''
-
+        # Retires to override the default value os 3 retries in urllib3
         self.retries = None
 
     @property

--- a/kubernetes/client/configuration.py
+++ b/kubernetes/client/configuration.py
@@ -106,6 +106,8 @@ class Configuration(with_metaclass(TypeWithDefault, object)):
         # Safe chars for path_param
         self.safe_chars_for_path_param = ''
 
+        self.retries = None
+
     @property
     def logger_file(self):
         """

--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -81,7 +81,7 @@ class RESTClientObject(object):
             addition_pool_args['assert_hostname'] = configuration.assert_hostname
 
 
-        if hasattr(configuration, "retries") and configuration.retries is not None:
+        if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
         if maxsize is None:

--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -80,7 +80,6 @@ class RESTClientObject(object):
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname
 
-
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 

--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -80,6 +80,10 @@ class RESTClientObject(object):
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname
 
+
+        if hasattr(configuration, "retries") and configuration.retries is not None:
+            addition_pool_args['retries'] = configuration.retries
+
         if maxsize is None:
             if configuration.connection_pool_maxsize is not None:
                 maxsize = configuration.connection_pool_maxsize


### PR DESCRIPTION
This PR addresses https://github.com/kubernetes-client/python/issues/652
Adding option in configuration and rest client object to send number of retries value to override the default value of 3 in urllib3. 
