### PR TITLE
Temporary patch for failed e2e tests

### DIFF
--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -45,7 +45,9 @@ fi
 docker --version
 
 # Get the latest stable version of kubernetes
-K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+# K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+# TODO: Temporary fix until minikube v1 is released
+K8S_VERSION='v1.13.5'
 echo "K8S_VERSION : ${K8S_VERSION}"
 
 echo "Starting docker service"


### PR DESCRIPTION
Temporary workaround for #793. Use k8s version 1.13.5 with minikube.
When minikube v1.0 is released this shall be replaced with an upgraded version of minikube. Marked with TODO.