### PR TITLE
Drop Python3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ matrix:
        env: TOXENV=docs
      - python: 2.7
        env: TOXENV=coverage,codecov
-     - python: 3.4
-       env: TOXENV=py34
      - python: 3.5
        env: TOXENV=py35
      - python: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37
+envlist = py27, py35, py36, py37
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*


### PR DESCRIPTION
 Python3.4 become EOL on 2019.03.18.

 https://www.python.org/dev/peps/pep-0429/

See also https://github.com/kubernetes-client/python-base/pull/127