### PR TITLE
Fix broken dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ certifi>=14.05.14 # MPL
 six>=1.9.0  # MIT
 python-dateutil>=2.5.3  # BSD
 setuptools>=21.0.0  # PSF/ZPL
-urllib3>=1.23  # MIT
 pyyaml>=3.12  # MIT
 google-auth>=1.0.1  # Apache-2.0
 ipaddress>=1.0.17;python_version=="2.7"  # PSF
 websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.* # LGPLv2+
 requests # Apache-2.0
 requests-oauthlib # ISC
+urllib3>=1.23  # MIT


### PR DESCRIPTION
All our libraries that depended on `kubernetes` started breaking today.
The reason is that pip does not do a good job properly resolving the compatible package versions.
It just install packages in order without caring about the incompatibilities.
The urllib3 package installed is incompatible with the `requests` package that's getting installed later.

Changing the order fixes the issue.

See https://github.com/kubeflow/pipelines/pull/1201

Log illustrating the issue:

```
$ python3 -m pip install kubernetes==8.0.0
Collecting kubernetes==8.0.0
...

Collecting urllib3!=1.21,>=1.19.1 (from kubernetes==8.0.0)
  Downloading https://files.pythonhosted.org/packages/81/9b/715e96377cc1f87e71d9d4259c6f88bf561a539622ba3042e73188e0bc2d/urllib3-1.25-py2.py3-none-any.whl (149kB)

Collecting requests (from kubernetes==8.0.0)
  Downloading https://files.pythonhosted.org/packages/7d/e3/20f3d364d6c8e5d2353c72a67778eb189176f08e873c9900e10c0287b84b/requests-2.21.0-py2.py3-none-any.whl (57kB)
...

requests 2.21.0 has requirement urllib3<1.25,>=1.21.1, but you'll have urllib3 1.25 which is incompatible.
Installing collected packages: certifi, urllib3, six, idna, chardet, requests, oauthlib, requests-oauthlib, websocket-client, cachetools, pyasn1, rsa, pyasn1-modules, google-auth, pyyaml, asn1crypto, pycparser, cffi, cryptography, PyJWT, python-dateutil, adal, kubernetes
Successfully installed PyJWT-1.7.1 adal-1.2.1 asn1crypto-0.24.0 cachetools-3.1.0 certifi-2019.3.9 cffi-1.12.3 chardet-3.0.4 cryptography-2.6.1 google-auth-1.6.3 idna-2.8 kubernetes-8.0.0 oauthlib-3.0.1 pyasn1-0.4.5 pyasn1-modules-0.2.4 pycparser-2.19 python-dateutil-2.8.0 pyyaml-5.1 requests-2.21.0 requests-oauthlib-1.2.0 rsa-4.0 six-1.12.0 urllib3-1.25 websocket-client-0.56.0
```

Then the packages fail at runtime.