### PR TITLE
Fix AttributeError in create_from_yaml

### DIFF
--- a/kubernetes/e2e_test/test_utils.py
+++ b/kubernetes/e2e_test/test_utils.py
@@ -113,6 +113,20 @@ class TestUtils(unittest.TestCase):
         rbac_api.delete_namespaced_role(
             name="pod-reader", namespace="default", body={})
 
+    def test_create_rbac_role_from_yaml_with_verbose_enabled(self):
+        """
+        Should be able to create an rbac role with verbose enabled.
+        """
+        k8s_client = client.api_client.ApiClient(configuration=self.config)
+        utils.create_from_yaml(
+            k8s_client, self.path_prefix + "rbac-role.yaml", verbose=True)
+        rbac_api = client.RbacAuthorizationV1Api(k8s_client)
+        rbac_role = rbac_api.read_namespaced_role(
+            name="pod-reader", namespace="default")
+        self.assertIsNotNone(rbac_role)
+        rbac_api.delete_namespaced_role(
+            name="pod-reader", namespace="default", body={})
+
     def test_create_deployment_non_default_namespace_from_yaml(self):
         """
         Should be able to create a namespace "dep",

--- a/kubernetes/utils/create_from_yaml.py
+++ b/kubernetes/utils/create_from_yaml.py
@@ -120,7 +120,10 @@ def create_from_yaml_single_item(
         resp = getattr(k8s_api, "create_{0}".format(kind))(
             body=yml_object, **kwargs)
     if verbose:
-        print("{0} created. status='{1}'".format(kind, str(resp.status)))
+        msg = "{0} created.".format(kind)
+        if hasattr(resp, 'status'):
+            msg += " status='{0}'".format(str(resp.status))
+        print(msg)
 
 
 class FailToCreateError(Exception):


### PR DESCRIPTION
Some models don't have attribute 'status', like V1ConfigMap,
V1ClusterRole, and V1NetworkPolicy. AttributeError would be raised if
these resources are created via create_from_yaml with verbose enabled.

This patch checks if attribute 'status' exists before accessing it.