### PR TITLE
Enhancements for example3.py and example4.py

### DIFF
--- a/examples/example3.py
+++ b/examples/example3.py
@@ -22,7 +22,7 @@ def main():
     config.load_kube_config()
 
     print("Supported APIs (* is preferred version):")
-    print("%-20s %s" %
+    print("%-40s %s" %
           ("core", ",".join(client.CoreApi().get_api_versions().versions)))
     for api in client.ApisApi().get_api_versions().groups:
         versions = []

--- a/examples/example4.py
+++ b/examples/example4.py
@@ -32,7 +32,7 @@ def main():
     # utility
     config.load_kube_config(context=option)
 
-    print("Active host is %s" % configuration.host)
+    print("Active host is %s" % configuration.Configuration().host)
 
     v1 = client.CoreV1Api()
     print("Listing pods with their IPs:")


### PR DESCRIPTION
- **example3.py** has different alignment for showing the core ApiVersion (*20*) and the other group ApiVersions (*40*).

- **example4.py** can not be run anymore:

`AttributeError: module 'kubernetes.config' has no attribute 'host'`

Fixed with calling Configuration() to get the active host.