### PR TITLE
Fix custom object patch API content type in release-10.0 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v10.0.1
+**Bug Fix:**
+- Fix content type regression in custom object patch API [kubernetes-client/python#866](https://github.com/kubernetes-client/python/issues/866)
+
 # v10.0.0
 **Bug Fix:**
 - Fix base64 padding for kube config [kubernetes-client/python-base#79](https://github.com/kubernetes-client/python-base/pull/79)

--- a/kubernetes/client/apis/custom_objects_api.py
+++ b/kubernetes/client/apis/custom_objects_api.py
@@ -1657,7 +1657,7 @@ class CustomObjectsApi(object):
 
         # HTTP header `Content-Type`
         header_params['Content-Type'] = self.api_client.\
-            select_header_content_type(['application/json-patch+json', 'application/merge-patch+json'])
+            select_header_content_type(['application/merge-patch+json', 'application/json-patch+json'])
 
         # Authentication setting
         auth_settings = ['BearerToken']
@@ -1781,7 +1781,7 @@ class CustomObjectsApi(object):
 
         # HTTP header `Content-Type`
         header_params['Content-Type'] = self.api_client.\
-            select_header_content_type(['application/json-patch+json', 'application/merge-patch+json'])
+            select_header_content_type(['application/merge-patch+json', 'application/json-patch+json'])
 
         # Authentication setting
         auth_settings = ['BearerToken']
@@ -1905,7 +1905,7 @@ class CustomObjectsApi(object):
 
         # HTTP header `Content-Type`
         header_params['Content-Type'] = self.api_client.\
-            select_header_content_type(['application/json-patch+json', 'application/merge-patch+json'])
+            select_header_content_type(['application/merge-patch+json', 'application/json-patch+json'])
 
         # Authentication setting
         auth_settings = ['BearerToken']
@@ -2036,7 +2036,7 @@ class CustomObjectsApi(object):
 
         # HTTP header `Content-Type`
         header_params['Content-Type'] = self.api_client.\
-            select_header_content_type(['application/json-patch+json', 'application/merge-patch+json'])
+            select_header_content_type(['application/merge-patch+json', 'application/json-patch+json'])
 
         # Authentication setting
         auth_settings = ['BearerToken']
@@ -2167,7 +2167,7 @@ class CustomObjectsApi(object):
 
         # HTTP header `Content-Type`
         header_params['Content-Type'] = self.api_client.\
-            select_header_content_type(['application/json-patch+json', 'application/merge-patch+json'])
+            select_header_content_type(['application/merge-patch+json', 'application/json-patch+json'])
 
         # Authentication setting
         auth_settings = ['BearerToken']
@@ -2298,7 +2298,7 @@ class CustomObjectsApi(object):
 
         # HTTP header `Content-Type`
         header_params['Content-Type'] = self.api_client.\
-            select_header_content_type(['application/json-patch+json', 'application/merge-patch+json'])
+            select_header_content_type(['application/merge-patch+json', 'application/json-patch+json'])
 
         # Authentication setting
         auth_settings = ['BearerToken']


### PR DESCRIPTION
Fix a regression in custom object patch API that can break existing clients who use JSON merge patch to patch custom objects.

ref: https://github.com/kubernetes-client/python/issues/866

**NOTE:** 
1. the bug doesn't exist in master branch. It was introduced in https://github.com/kubernetes-client/python/pull/864#discussion_r299694534
2. e2e test in master branch didn't exercise CRD and CR APIs. I added a test to demo the fix. See #885 and #886. We can merge that test into master branch later 
3. we don't cherrypick the test into the release branch, since our travis-ci only works with the master branch. 
4. long-term plan: https://github.com/kubernetes-client/python/issues/866#issuecomment-512564647

/assign @yliaog 
/kind bug
/priority critical-urgent