### PR TITLE
Update docs python version for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
        env: TOXENV=py27-functional
      - python: 2.7
        env: TOXENV=update-pycodestyle
-     - python: 2.7
+     - python: 3.7
        env: TOXENV=docs
      - python: 2.7
        env: TOXENV=coverage,codecov


### PR DESCRIPTION
See [this discussion](https://stackoverflow.com/questions/46223509/sphinx-python-importerror-cannot-import-name) here:

We'll need to use Python 3 to build the docs. Otherwise we'll see CI fail such as [this](https://travis-ci.org/micw523/python/jobs/562368779).