### PR TITLE
Pin docutils version due to breaking release

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,6 +6,7 @@ py>=1.4.31
 randomize>=0.13
 mock>=2.0.0
 sphinx>=1.2.1,!=1.3b1,<1.4 # BSD
+docutils<0.15
 recommonmark
 codecov>=1.4.0
 pycodestyle


### PR DESCRIPTION
Causing doc tests to fail (first seen here https://travis-ci.org/kubernetes-client/python-base/jobs/562820981)

Looks like there was a new release of docutils 2019-07-21 (https://pypi.org/project/docutils/0.15/#history), it doesn't seem to work with sphinx anymore. This PR pins it to the previous version, which should at least keep tests passing until a longer-term solution is found.

Oddly it doesn't seem like all tests are affected (https://travis-ci.org/kubernetes-client/python/jobs/562758732 passed), not sure why yet.

Edit: It fails in python-base but not in python because python-base is generating docs in python2, and python is generating docs with python3. The breakage appears to only affect python2.