### PR TITLE
Python 3.4 is no longer supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
This update the setup metadata to indicate this.
This is  a follow up of #807 .