### PR TITLE
Update urllib3 for CVE-2019-11324

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ ipaddress>=1.0.17;python_version=="2.7"  # PSF
 websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.* # LGPLv2+
 requests # Apache-2.0
 requests-oauthlib # ISC
-urllib3>=1.23  # MIT
+urllib3>=1.24.2  # MIT


### PR DESCRIPTION
CVE-2019-11324 affects all urllib3 versions before 1.24.2. We should bump the minimum version required.