### PR TITLE
Request 2 CPUs per Travis CI job

### DIFF
--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -30,6 +30,9 @@ trap "clean_exit" EXIT
 # Switch off SE-Linux
 setenforce 0
 
+# Request at least 2 CPUs from Travis CI per job
+export TRAVIS_WORKER_DOCKER_CPUS=2
+
 # Mount root to fix dns issues
 # Define $HOME since somehow this is not defined
 HOME=/home/travis


### PR DESCRIPTION
Add an environmental variable according to [this help](https://docs.travis-ci.com/user/enterprise/worker-configuration/#configuring-the-number-of-concurrent-jobs) to avoid test flakes