### PR TITLE
Add a test for custom object operations

### DIFF
--- a/kubernetes/client/models/v1beta1_custom_resource_definition_status.py
+++ b/kubernetes/client/models/v1beta1_custom_resource_definition_status.py
@@ -101,8 +101,6 @@ class V1beta1CustomResourceDefinitionStatus(object):
         :param conditions: The conditions of this V1beta1CustomResourceDefinitionStatus.
         :type: list[V1beta1CustomResourceDefinitionCondition]
         """
-        if conditions is None:
-            raise ValueError("Invalid value for `conditions`, must not be `None`")
 
         self._conditions = conditions
 


### PR DESCRIPTION
pick the test from https://github.com/kubernetes-client/python/pull/886 to prevent breaking change like https://github.com/kubernetes-client/python/issues/866 from happening