### PR TITLE
do not share authorization information when creating new client configuration

### DIFF
--- a/kubernetes/client/configuration.py
+++ b/kubernetes/client/configuration.py
@@ -32,7 +32,14 @@ class TypeWithDefault(type):
     def __call__(cls):
         if cls._default == None:
             cls._default = type.__call__(cls)
-        return copy.copy(cls._default)
+        new_instance =  copy.copy(cls._default)
+        # second level shadow copy for fields that should not be shared.
+        for k in ["api_key_prefix", "api_key"]:
+            if not hasattr(new_instance, k):
+                continue
+            setattr(new_instance, k, copy.copy(getattr(new_instance, k)))
+        return new_instance
+
 
     def set_default(cls, default):
         cls._default = copy.copy(default)

--- a/kubernetes/test/test_multiple_client_configuration.py
+++ b/kubernetes/test/test_multiple_client_configuration.py
@@ -1,0 +1,28 @@
+"""
+    Test cases for multiple client configuration usage.
+"""
+
+import unittest
+from kubernetes.client import Configuration
+
+
+class TestMultipleClientConfiguration(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def testAuthinfoNotShared(self):
+        conf_a = Configuration()
+        conf_a.api_key['authorization'] = "token a"
+        conf_a.api_key_prefix['authorization'] = "Bearer"
+        conf_b = Configuration()
+        conf_b.api_key['authorization'] = "token b"
+        conf_b.api_key_prefix['authorization'] = "Token"
+        self.assertEqual(conf_a.api_key['authorization'], "token a")
+        self.assertEqual(conf_a.api_key_prefix['authorization'], "Bearer")
+        self.assertEqual(conf_b.api_key['authorization'], "token b")
+        self.assertEqual(conf_b.api_key_prefix['authorization'], "Token")
+


### PR DESCRIPTION
When using multiple instances of client.Configurations to mange multiple k8s cluster via bearer token, the token set last is used for all the client configuration since client.Configuration has changed somewhere during development to shadow copy default instance using metaclass, causing client got 401 response from apiserver except the last client as describe in issue https://github.com/kubernetes-client/python/issues/932

This code would make second level of shadow copy for fields that should not be shared.
Before the code change, the new test would fail
```
$ python -m unittest test.test_multiple_client_configuration
F
======================================================================
FAIL: testAuthinfoNotShared (test.test_multiple_client_configuration.TestMultipleClientConfiguration)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_multiple_client_configuration.py", line 24, in testAuthinfoNotShared
    self.assertEqual(conf_a.api_key['authorization'], "token a")
AssertionError: 'token b' != 'token a'

----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (failures=1)
```
….

Signed-off-by: zq-david-wang <00107082@163.com>