### PR TITLE
content-type for patch commands

### DIFF
--- a/examples/custom_object.py
+++ b/examples/custom_object.py
@@ -29,6 +29,19 @@ spec:
     - name: v1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
   scope: Namespaced
   names:
     plural: crontabs
@@ -68,6 +81,28 @@ def main():
         body=my_resource,
     )
     print("Resource created")
+
+    # get the resource and print out data
+    resource = api.get_namespaced_custom_object(
+        group="stable.example.com",
+        version="v1",
+        name="my-new-cron-object",
+        namespace="default",
+        plural="crontabs",
+    )
+    print("Resource details:")
+    pprint(resource)
+
+    # patch the resource
+    resource = api.patch_namespaced_custom_object(
+        group="stable.example.com",
+        version="v1",
+        name="my-new-cron-object",
+        namespace="default",
+        plural="crontabs",
+        body={'image': 'my-awesome-cron-image:2'},
+        content_type="application/merge-patch+json"
+    )
 
     # get the resource and print out data
     resource = api.get_namespaced_custom_object(

--- a/kubernetes/client/api/core_v1_api.py
+++ b/kubernetes/client/api/core_v1_api.py
@@ -18250,6 +18250,7 @@ class CoreV1Api(object):
         all_params.extend(
             [
                 'async_req',
+                'content_type',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout'
@@ -18308,8 +18309,10 @@ class CoreV1Api(object):
             ['application/json', 'application/yaml', 'application/vnd.kubernetes.protobuf'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json-patch+json', 'application/merge-patch+json', 'application/strategic-merge-patch+json', 'application/apply-patch+yaml'])  # noqa: E501
+        header_params['Content-Type'] = local_var_params.get('content_type',
+            self.api_client.select_header_content_type(['application/json-patch+json',
+                'application/merge-patch+json', 'application/strategic-merge-patch+json', 'application/apply-patch+yaml'],
+                'PATCH', body_params))
 
         # Authentication setting
         auth_settings = ['BearerToken']  # noqa: E501
@@ -20590,6 +20593,7 @@ class CoreV1Api(object):
         all_params.extend(
             [
                 'async_req',
+                'content_type',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout'
@@ -20648,8 +20652,10 @@ class CoreV1Api(object):
             ['application/json', 'application/yaml', 'application/vnd.kubernetes.protobuf'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json-patch+json', 'application/merge-patch+json', 'application/strategic-merge-patch+json', 'application/apply-patch+yaml'])  # noqa: E501
+        header_params['Content-Type'] = local_var_params.get('content_type',
+            self.api_client.select_header_content_type(['application/json-patch+json',
+                'application/merge-patch+json', 'application/strategic-merge-patch+json', 'application/apply-patch+yaml'],
+                'PATCH', body_params))
 
         # Authentication setting
         auth_settings = ['BearerToken']  # noqa: E501

--- a/kubernetes/client/api/custom_objects_api.py
+++ b/kubernetes/client/api/custom_objects_api.py
@@ -2336,6 +2336,7 @@ class CustomObjectsApi(object):
         all_params.extend(
             [
                 'async_req',
+                'content_type',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout'
@@ -2404,8 +2405,8 @@ class CustomObjectsApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/merge-patch+json'])  # noqa: E501
+        header_params['Content-Type'] = local_var_params.get('content_type', self.api_client.\
+            select_header_content_type(['application/merge-patch+json'], 'PATCH', body_params))
 
         # Authentication setting
         auth_settings = ['BearerToken']  # noqa: E501
@@ -2505,6 +2506,7 @@ class CustomObjectsApi(object):
         all_params.extend(
             [
                 'async_req',
+                'content_type',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout'
@@ -2573,8 +2575,8 @@ class CustomObjectsApi(object):
             ['application/json', 'application/yaml', 'application/vnd.kubernetes.protobuf'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/merge-patch+json'])  # noqa: E501
+        header_params['Content-Type'] = local_var_params.get('content_type', self.api_client.\
+            select_header_content_type(['application/merge-patch+json'], 'PATCH', body_params))
 
         # Authentication setting
         auth_settings = ['BearerToken']  # noqa: E501
@@ -2674,6 +2676,7 @@ class CustomObjectsApi(object):
         all_params.extend(
             [
                 'async_req',
+                'content_type',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout'
@@ -2742,8 +2745,8 @@ class CustomObjectsApi(object):
             ['application/json', 'application/yaml', 'application/vnd.kubernetes.protobuf'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/merge-patch+json'])  # noqa: E501
+        header_params['Content-Type'] = local_var_params.get('content_type', self.api_client.\
+            select_header_content_type(['application/merge-patch+json'], 'PATCH', body_params))
 
         # Authentication setting
         auth_settings = ['BearerToken']  # noqa: E501
@@ -2846,6 +2849,7 @@ class CustomObjectsApi(object):
         all_params.extend(
             [
                 'async_req',
+                'content_type',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout'
@@ -2920,8 +2924,8 @@ class CustomObjectsApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/merge-patch+json'])  # noqa: E501
+        header_params['Content-Type'] = local_var_params.get('content_type', self.api_client.\
+            select_header_content_type(['application/merge-patch+json'], 'PATCH', body_params))
 
         # Authentication setting
         auth_settings = ['BearerToken']  # noqa: E501
@@ -3024,6 +3028,7 @@ class CustomObjectsApi(object):
         all_params.extend(
             [
                 'async_req',
+                'content_type',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout'
@@ -3098,8 +3103,8 @@ class CustomObjectsApi(object):
             ['application/json', 'application/yaml', 'application/vnd.kubernetes.protobuf'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/merge-patch+json'])  # noqa: E501
+        header_params['Content-Type'] = local_var_params.get('content_type', self.api_client.\
+            select_header_content_type(['application/merge-patch+json'], 'PATCH', body_params))
 
         # Authentication setting
         auth_settings = ['BearerToken']  # noqa: E501
@@ -3202,6 +3207,7 @@ class CustomObjectsApi(object):
         all_params.extend(
             [
                 'async_req',
+                'content_type',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout'
@@ -3276,8 +3282,8 @@ class CustomObjectsApi(object):
             ['application/json', 'application/yaml', 'application/vnd.kubernetes.protobuf'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/merge-patch+json'])  # noqa: E501
+        header_params['Content-Type'] = local_var_params.get('content_type', self.api_client.\
+            select_header_content_type(['application/merge-patch+json'], 'PATCH', body_params))
 
         # Authentication setting
         auth_settings = ['BearerToken']  # noqa: E501

--- a/kubernetes/client/api_client.py
+++ b/kubernetes/client/api_client.py
@@ -494,7 +494,7 @@ class ApiClient(object):
         else:
             return ', '.join(accepts)
 
-    def select_header_content_type(self, content_types):
+    def select_header_content_type(self, content_types, method=None, body=None):
         """Returns `Content-Type` based on an array of content_types provided.
 
         :param content_types: List of content-types.
@@ -504,6 +504,21 @@ class ApiClient(object):
             return 'application/json'
 
         content_types = [x.lower() for x in content_types]
+
+        if method and body and method == 'PATCH':
+            # try to select valid content_type
+            if 'application/json-patch+json' in content_types and \
+               'application/merge-patch+json' in content_types:
+                if isinstance(body, list):
+                    return 'application/json-patch+json'
+                else:
+                    # ---
+                    # kubernetes specific - application/strategic-merge-patch+json
+                    # applied as a patch or subclass
+                    if 'application/strategic-merge-patch+json' in content_types:
+                        return 'application/strategic-merge-patch+json'
+                    # ---
+                    return 'application/merge-patch+json'
 
         if 'application/json' in content_types or '*/*' in content_types:
             return 'application/json'

--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -157,10 +157,6 @@ class RESTClientObject(object):
                 if query_params:
                     url += '?' + urlencode(query_params)
                 if re.search('json', headers['Content-Type'], re.IGNORECASE):
-                    if headers['Content-Type'] == 'application/json-patch+json':
-                        if not isinstance(body, list):
-                            headers['Content-Type'] = \
-                                'application/strategic-merge-patch+json'
                     request_body = None
                     if body is not None:
                         request_body = json.dumps(body)


### PR DESCRIPTION
Hi all.

In this PR I'd like to discuss possible solution for problems with selecting content-type when K8s' objects are patching. This problem is nicely documented in https://github.com/kubernetes-client/python/issues/866 and https://github.com/tomplus/kubernetes_asyncio/issues/68

This idea is to introduce a new parameter in ApiClient to be able to control a return from the `select_header_content_type` method and remove the problematic detection from rest.py. Optionally we can add this as an argument to each patch method.
It'll be breaking change if an application uses patch_* methods.

Please take a look. If we accept the solution I prepare PR in openapi-generator and temporary patch for this repo.

cc: @roycaihw @yliaog @HaraldGustafsson @nolar 

Thanks.