### PR TITLE
Address API Changes Introduced in k8s v1.16

### DIFF
--- a/kubernetes/e2e_test/test_apps.py
+++ b/kubernetes/e2e_test/test_apps.py
@@ -17,12 +17,12 @@ import uuid
 import yaml
 
 from kubernetes.client import api_client
-from kubernetes.client.apis import extensions_v1beta1_api
+from kubernetes.client.apis import apps_v1_api
 from kubernetes.client.models import v1_delete_options
 from kubernetes.e2e_test import base
 
 
-class TestClientExtensions(unittest.TestCase):
+class TestClientApps(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -30,14 +30,17 @@ class TestClientExtensions(unittest.TestCase):
 
     def test_create_deployment(self):
         client = api_client.ApiClient(configuration=self.config)
-        api = extensions_v1beta1_api.ExtensionsV1beta1Api(client)
+        api = apps_v1_api.AppsV1Api(client)
         name = 'nginx-deployment-' + str(uuid.uuid4())
-        deployment = '''apiVersion: extensions/v1beta1
+        deployment = '''apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: %s
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:
@@ -45,7 +48,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.7.9
+        image: nginx:1.15.4
         ports:
         - containerPort: 80
 '''
@@ -60,16 +63,19 @@ spec:
 
     def test_create_daemonset(self):
         client = api_client.ApiClient(configuration=self.config)
-        api = extensions_v1beta1_api.ExtensionsV1beta1Api(client)
+        api = apps_v1_api.AppsV1Api(client)
         name = 'nginx-app-' + str(uuid.uuid4())
         daemonset = {
-            'apiVersion': 'extensions/v1beta1',
+            'apiVersion': 'apps/v1',
             'kind': 'DaemonSet',
             'metadata': {
                 'labels': {'app': 'nginx'},
                 'name': '%s' % name,
             },
             'spec': {
+                'selector': {
+                    'matchLabels': {'app': 'nginx'},
+                },
                 'template': {
                     'metadata': {
                         'labels': {'app': 'nginx'},
@@ -77,7 +83,7 @@ spec:
                     'spec': {
                         'containers': [
                             {'name': 'nginx-app',
-                             'image': 'nginx:1.10'},
+                             'image': 'nginx:1.15.4'},
                         ],
                     },
                 },

--- a/kubernetes/e2e_test/test_utils.py
+++ b/kubernetes/e2e_test/test_utils.py
@@ -41,12 +41,12 @@ class TestUtils(unittest.TestCase):
 
     def test_create_apps_deployment_from_yaml(self):
         """
-        Should be able to create an apps/v1beta1 deployment.
+        Should be able to create an apps/v1 deployment.
         """
         k8s_client = client.api_client.ApiClient(configuration=self.config)
         utils.create_from_yaml(
             k8s_client, self.path_prefix + "apps-deployment.yaml")
-        app_api = client.AppsV1beta1Api(k8s_client)
+        app_api = client.AppsV1Api(k8s_client)
         dep = app_api.read_namespaced_deployment(name="nginx-app",
                                                  namespace="default")
         self.assertIsNotNone(dep)
@@ -68,7 +68,7 @@ class TestUtils(unittest.TestCase):
 
         utils.create_from_dict(k8s_client, yml_obj)
 
-        app_api = client.AppsV1beta1Api(k8s_client)
+        app_api = client.AppsV1Api(k8s_client)
         dep = app_api.read_namespaced_deployment(name="nginx-app-3",
                                                  namespace="default")
         self.assertIsNotNone(dep)
@@ -289,7 +289,7 @@ class TestUtils(unittest.TestCase):
         utils.create_from_yaml(
             k8s_client, self.path_prefix + "multi-resource-with-list.yaml")
         core_api = client.CoreV1Api(k8s_client)
-        app_api = client.AppsV1beta1Api(k8s_client)
+        app_api = client.AppsV1Api(k8s_client)
         pod_0 = core_api.read_namespaced_pod(
             name="mock-pod-0", namespace="default")
         self.assertIsNotNone(pod_0)
@@ -365,15 +365,16 @@ class TestUtils(unittest.TestCase):
             name="triple-nginx", namespace="default",
             body={})
 
-    def test_create_namespaces_apps_deployment_from_yaml(self):
+    def test_create_namespaced_apps_deployment_from_yaml(self):
         """
-        Should be able to create an apps/v1beta1 deployment.
+        Should be able to create an apps/v1beta1 deployment
+		in a test namespace.
         """
         k8s_client = client.api_client.ApiClient(configuration=self.config)
         utils.create_from_yaml(
             k8s_client, self.path_prefix + "apps-deployment.yaml",
             namespace=self.test_namespace)
-        app_api = client.AppsV1beta1Api(k8s_client)
+        app_api = client.AppsV1Api(k8s_client)
         dep = app_api.read_namespaced_deployment(name="nginx-app",
                                                  namespace=self.test_namespace)
         self.assertIsNotNone(dep)
@@ -391,7 +392,7 @@ class TestUtils(unittest.TestCase):
             k8s_client, self.path_prefix + "multi-resource-with-list.yaml",
             namespace=self.test_namespace)
         core_api = client.CoreV1Api(k8s_client)
-        app_api = client.AppsV1beta1Api(k8s_client)
+        app_api = client.AppsV1Api(k8s_client)
         pod_0 = core_api.read_namespaced_pod(
             name="mock-pod-0", namespace=self.test_namespace)
         self.assertIsNotNone(pod_0)

--- a/kubernetes/e2e_test/test_yaml/apps-deployment.yaml
+++ b/kubernetes/e2e_test/test_yaml/apps-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-app

--- a/kubernetes/e2e_test/test_yaml/multi-resource-with-list.yaml
+++ b/kubernetes/e2e_test/test_yaml/multi-resource-with-list.yaml
@@ -24,7 +24,7 @@ items:
       image: busybox
       command: ['sh', '-c', 'echo Hello Kubernetes! && sleep 3600']
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mock


### PR DESCRIPTION
Fixes #963 .
This PR:
- Upgrades all apps/v1beta1 yamls to apps/v1. Ref https://github.com/kubernetes/kubernetes/pull/70672
- Changes tests originally written for extensions/v1beta1 to apps/v1.
- Add submodule commits for the exit code and dynamic client to fix e2e test errors.