### PR TITLE
Enable testing for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ matrix:
        env: TOXENV=py37
      - python: 3.7
        env: TOXENV=py37-functional
+     - python: 3.8
+       env: TOXENV=py38
+     - python: 3.8
+       env: TOXENV=py38-functional
 
 install:
   - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -77,5 +77,6 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py27, py35, py36, py37
+envlist =
+   py27, py3{5,6,7,8}
+   py27-functional, py3{5,6,7,8}-functional
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*
@@ -9,7 +11,8 @@ deps = -r{toxinidir}/test-requirements.txt
        -r{toxinidir}/requirements.txt
 commands =
    python -V
-   pytest -vvv -s --ignore=kubernetes/e2e_test
+   !functional: pytest -vvv -s --ignore=kubernetes/e2e_test
+   functional: {toxinidir}/scripts/kube-init.sh pytest -vvv -s []
 
 [testenv:docs]
 commands =
@@ -18,26 +21,6 @@ commands =
 [testenv:update-pycodestyle]
 commands =
    {toxinidir}/scripts/update-pycodestyle.sh
-
-[testenv:py27-functional]
-commands =
-   python -V
-   {toxinidir}/scripts/kube-init.sh pytest -vvv -s []
-
-[testenv:py35-functional]
-commands =
-   python -V
-   {toxinidir}/scripts/kube-init.sh pytest -vvv -s []
-
-[testenv:py36-functional]
-commands =
-   python -V
-   {toxinidir}/scripts/kube-init.sh pytest -vvv -s []
-
-[testenv:py37-functional]
-commands =
-   python -V
-   {toxinidir}/scripts/kube-init.sh pytest -vvv -s []
 
 [testenv:coverage]
 commands =


### PR DESCRIPTION
Hello,

Python 3.8 is [almost there](https://www.python.org/dev/peps/pep-0569/#schedule), so I believe that it would be nice to have tests for it on CI.

Best regards!