### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/kubernetes/utils/create_from_yaml.py
+++ b/kubernetes/utils/create_from_yaml.py
@@ -102,7 +102,7 @@ def create_from_dict(k8s_client, data, verbose=False, namespace='default',
         for yml_object in data["items"]:
             # Mitigate cases when server returns a xxxList object
             # See kubernetes-client/python#586
-            if kind is not "":
+            if kind != "":
                 yml_object["apiVersion"] = data["apiVersion"]
                 yml_object["kind"] = kind
             try:


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise SyntaxWarnings so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8