### PR TITLE
Enables the use of dynamic client

### DIFF
--- a/kubernetes/__init__.py
+++ b/kubernetes/__init__.py
@@ -18,6 +18,7 @@ __version__ = "11.0.0-snapshot"
 
 import kubernetes.client
 import kubernetes.config
+import kubernetes.dynamic
 import kubernetes.watch
 import kubernetes.stream
 import kubernetes.utils

--- a/kubernetes/dynamic
+++ b/kubernetes/dynamic
@@ -1,0 +1,1 @@
+base/dynamic


### PR DESCRIPTION
When I'm switching our ```create_from_yaml``` utility to the dynamic client to allow easier treatment of the CRDs, I found out that the dynamic client was never imported into the package and cannot be used. This PR enables the users to actually use the dynamic client.