### PR TITLE
Fix deprecation warning in e2e tests

### DIFF
--- a/kubernetes/e2e_test/test_apps.py
+++ b/kubernetes/e2e_test/test_apps.py
@@ -17,7 +17,7 @@ import uuid
 import yaml
 
 from kubernetes.client import api_client
-from kubernetes.client.apis import apps_v1_api
+from kubernetes.client.api import apps_v1_api
 from kubernetes.client.models import v1_delete_options
 from kubernetes.e2e_test import base
 

--- a/kubernetes/e2e_test/test_batch.py
+++ b/kubernetes/e2e_test/test_batch.py
@@ -16,7 +16,7 @@ import unittest
 import uuid
 
 from kubernetes.client import api_client
-from kubernetes.client.apis import batch_v1_api
+from kubernetes.client.api import batch_v1_api
 from kubernetes.e2e_test import base
 
 

--- a/kubernetes/e2e_test/test_client.py
+++ b/kubernetes/e2e_test/test_client.py
@@ -18,7 +18,7 @@ import unittest
 import uuid
 
 from kubernetes.client import api_client
-from kubernetes.client.apis import core_v1_api
+from kubernetes.client.api import core_v1_api
 from kubernetes.e2e_test import base
 from kubernetes.stream import stream
 from kubernetes.stream.ws_client import ERROR_CHANNEL


### PR DESCRIPTION
Since the apis package is renamed to api, our e2e tests should do the same thing as well to avoid deprecation warnings raised by ourselves.