### PR TITLE
Fix Custom Objects API example

### DIFF
--- a/examples/custom_object.py
+++ b/examples/custom_object.py
@@ -53,8 +53,10 @@ def main():
         "apiVersion": "stable.example.com/v1",
         "kind": "CronTab",
         "metadata": {"name": "my-new-cron-object"},
-        "cronSpec": "* * * * */5",
-        "image": "my-awesome-cron-image",
+        "spec": {
+            "cronSpec": "* * * * */5",
+            "image": "my-awesome-cron-image"
+        }
     }
 
     # create the resource


### PR DESCRIPTION
I was trying to create a namespaced custom object using the provided example without success. I found that the resource that the example provides is missing the `spec` wrapper. 

I was able to create a custom object successfully after changing that. Some reference documentation regarding the custom resource definition:
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#customresourcedefinition-v1beta1-apiextensions-k8s-io

Thanks!