### PR TITLE
Rest: Warn about swallowed _request_timeout

### DIFF
--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -17,6 +17,7 @@ import json
 import logging
 import re
 import ssl
+import warnings
 
 import certifi
 # python 2 and python 3 compatibility library
@@ -145,6 +146,11 @@ class RESTClientObject(object):
                   len(_request_timeout) == 2):
                 timeout = urllib3.Timeout(
                     connect=_request_timeout[0], read=_request_timeout[1])
+            else:
+                warnings.warn(
+                    "_request_timeout ignored because it is neither an "
+                    "integer, nor a 2-tuple. This will become an exception "
+                    "in the future.", DeprecationWarning)
 
         if 'Content-Type' not in headers:
             headers['Content-Type'] = 'application/json'


### PR DESCRIPTION
If `_request_timeout` is neither an int, nor a 2-tuple, it is swallowed without further notice which is a rather unfortunate because the level developers would have to look for this issue is pretty deep.

This actually leads to confusion already, see https://github.com/apache/airflow/pull/6643#issuecomment-575438090

While it would break backwards compatibility to raise an exception, we should at least warn the developer.

This is meant as kind of a discussion base. I am not fully aware of how you developers would like to deal with this. Feedback appreciated :slightly_smiling_face: 