### PR TITLE
Cleanup ThreadPool with atexit rather than __del__

### DIFF
--- a/kubernetes/test/test_api_client.py
+++ b/kubernetes/test/test_api_client.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+
+
+import atexit
+import weakref
+import unittest
+
+import kubernetes
+
+
+class TestApiClient(unittest.TestCase):
+
+    def test_context_manager_closes_threadpool(self):
+        with kubernetes.client.ApiClient() as client:
+            self.assertIsNotNone(client.pool)
+            pool_ref = weakref.ref(client._pool)
+            self.assertIsNotNone(pool_ref())
+        self.assertIsNone(pool_ref())
+
+    def test_atexit_closes_threadpool(self):
+        client = kubernetes.client.ApiClient()
+        self.assertIsNotNone(client.pool)
+        self.assertIsNotNone(client._pool)
+        atexit._run_exitfuncs()
+        self.assertIsNone(client._pool)


### PR DESCRIPTION
This removes the `__del__` function from the generated Python client,
and replaces it with a `cleanup` function. When a `ThreadPool` is created,
the `cleanup` function is registered with the `atexit` module.

This PR also allows the client to be used as a context manager, which
will automatically clean up after itself rather than having to wait til
process exit.

This fixes #1037, where the API client could hang indefinitely at
garbage collection.