### PR TITLE
cherry-pick of #1073 to release-12.0: Fix python3 hang

### DIFF
--- a/kubernetes/test/test_api_client.py
+++ b/kubernetes/test/test_api_client.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+
+
+import atexit
+import weakref
+import unittest
+
+import kubernetes
+
+
+class TestApiClient(unittest.TestCase):
+
+    def test_context_manager_closes_threadpool(self):
+        with kubernetes.client.ApiClient() as client:
+            self.assertIsNotNone(client.pool)
+            pool_ref = weakref.ref(client._pool)
+            self.assertIsNotNone(pool_ref())
+        self.assertIsNone(pool_ref())
+
+    def test_atexit_closes_threadpool(self):
+        client = kubernetes.client.ApiClient()
+        self.assertIsNotNone(client.pool)
+        self.assertIsNotNone(client._pool)
+        atexit._run_exitfuncs()
+        self.assertIsNone(client._pool)


### PR DESCRIPTION
Cleanup ThreadPool with atexit rather than __del__

(cherry picked from commit 0976d59d6ff206f2f428cabc7a6b7b1144843b2a)

Original PR: #1073