### PR TITLE
cherry-pick of #1073 to release-11.0: Fix python3 hang

### DIFF
--- a/kubernetes/client/api_client.py
+++ b/kubernetes/client/api_client.py
@@ -10,6 +10,7 @@
 
 from __future__ import absolute_import
 
+import atexit
 import datetime
 import json
 import mimetypes
@@ -77,11 +78,19 @@ class ApiClient(object):
         # Set default User-Agent.
         self.user_agent = 'OpenAPI-Generator/11.0.0b2/python'
 
-    def __del__(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
         if self._pool:
             self._pool.close()
             self._pool.join()
             self._pool = None
+            if hasattr(atexit, 'unregister'):
+                atexit.unregister(self.close)
 
     @property
     def pool(self):
@@ -89,6 +98,7 @@ class ApiClient(object):
          avoids instantiating unused threadpool for blocking clients.
         """
         if self._pool is None:
+            atexit.register(self.close)
             self._pool = ThreadPool(self.pool_threads)
         return self._pool
 

--- a/kubernetes/test/test_api_client.py
+++ b/kubernetes/test/test_api_client.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+
+
+import atexit
+import weakref
+import unittest
+
+import kubernetes
+
+
+class TestApiClient(unittest.TestCase):
+
+    def test_context_manager_closes_threadpool(self):
+        with kubernetes.client.ApiClient() as client:
+            self.assertIsNotNone(client.pool)
+            pool_ref = weakref.ref(client._pool)
+            self.assertIsNotNone(pool_ref())
+        self.assertIsNone(pool_ref())
+
+    def test_atexit_closes_threadpool(self):
+        client = kubernetes.client.ApiClient()
+        self.assertIsNotNone(client.pool)
+        self.assertIsNotNone(client._pool)
+        atexit._run_exitfuncs()
+        self.assertIsNone(client._pool)


### PR DESCRIPTION
Cleanup ThreadPool with atexit rather than __del__

(cherry picked from commit 0976d59d6ff206f2f428cabc7a6b7b1144843b2a)

Original PR: #1073