### PR TITLE
make dateutil mandatory for api client

### DIFF
--- a/kubernetes/client/api_client.py
+++ b/kubernetes/client/api_client.py
@@ -18,6 +18,7 @@ from multiprocessing.pool import ThreadPool
 import os
 import re
 import tempfile
+import dateutil.parser
 
 # python 2 and python 3 compatibility library
 import six
@@ -582,10 +583,7 @@ class ApiClient(object):
         :return: date.
         """
         try:
-            from dateutil.parser import parse
-            return parse(string).date()
-        except ImportError:
-            return string
+            return dateutil.parser.parse(string).date()
         except ValueError:
             raise rest.ApiException(
                 status=0,
@@ -601,10 +599,7 @@ class ApiClient(object):
         :return: datetime.
         """
         try:
-            from dateutil.parser import parse
-            return parse(string)
-        except ImportError:
-            return string
+            return dateutil.parser.parse(string)
         except ValueError:
             raise rest.ApiException(
                 status=0,


### PR DESCRIPTION
Avoids differing incompatible return types depending on what modules are
installed at runtime.
This is backward incompatible though likely the less breaking variation
as most environments should have dateutils installed due to the
requirements.txt.

Closes gh-1081