### PR TITLE
fix: e2e tests with conntrack required by k8s/minikube

### DIFF
--- a/scripts/kube-init.sh
+++ b/scripts/kube-init.sh
@@ -35,6 +35,10 @@ setenforce 0
 HOME=/home/travis
 sudo mount --make-rshared /
 
+# Install conntrack (required by minikube/K8s 1.18+)
+sudo apt-get update
+sudo apt-get install -y conntrack
+
 # Install docker if needed
 path_to_executable=$(which docker)
 if [ -x "$path_to_executable" ] ; then


### PR DESCRIPTION
The latest version of minikube/k8s requires conntrack and e2e tests fail with the error:

`The none driver requires conntrack to be installed for kubernetes version 1.18.0.`

Ref: kubernetes/minikube#7179