### PR TITLE
Add github actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,33 @@
+name: Kubernetes Python Client - Validation
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Install Tox and any other packages
+      run: pip install tox
+    - name: Run Tox
+      run: tox -e py  # Run tox using the version of Python in `PATH`


### PR DESCRIPTION
ref: https://github.com/kubernetes-client/python/issues/1025

Travis ci is having trouble reporting job status back in this repo. Trying out Github Actions since it's been used in many repos in this org ([java](https://github.com/kubernetes-client/java/tree/master/.github/workflows), [javascript](https://github.com/kubernetes-client/javascript/tree/master/.github/workflows), [csharp](https://github.com/kubernetes-client/csharp/tree/master/.github/workflows)) and some repo in the kubernetes org ([utils](https://github.com/kubernetes/utils/tree/master/.github/workflows))

Notes: 
- Currently test results are still visible in https://travis-ci.org/github/kubernetes-client/python/pull_requests
- Mostly this file is modeled after https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions and https://github.com/kubernetes-client/javascript/blob/master/.github/workflows/test.yml

Followups: 
- After we get CI back, support publishing to Pypi following https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
- Remove .travis.yml to disable travis ci after github actions works. 

/cc @palnabarun @fabianvf @MoShitrit 