### PR TITLE
Add dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "03:00"


### PR DESCRIPTION
This adds dependabot, which will automatically send PRs to keep dependencies up to date.

See for example:
https://github.com/kubernetes-client/java/pull/1282