### PR TITLE
Returns the created k8s objects in create_from_{dict,yaml}.

### DIFF
--- a/kubernetes/utils/create_from_yaml.py
+++ b/kubernetes/utils/create_from_yaml.py
@@ -52,6 +52,9 @@ def create_from_yaml(
         processing of the request.
         Valid values are: - All: all dry run stages will be processed
 
+    Returns:
+        The created kubernetes API objects.
+
     Raises:
         FailToCreateError which holds list of `client.rest.ApiException`
         instances for each object that failed to create.
@@ -60,15 +63,19 @@ def create_from_yaml(
         yml_document_all = yaml.safe_load_all(f)
 
         failures = []
+        k8s_objects = []
         for yml_document in yml_document_all:
             try:
-                create_from_dict(k8s_client, yml_document, verbose,
-                                 namespace=namespace,
-                                 **kwargs)
+                created = create_from_dict(k8s_client, yml_document, verbose,
+                                           namespace=namespace,
+                                           **kwargs)
+                k8s_objects.append(created)
             except FailToCreateError as failure:
                 failures.extend(failure.api_exceptions)
         if failures:
             raise FailToCreateError(failures)
+
+        return k8s_objects
 
 
 def create_from_dict(k8s_client, data, verbose=False, namespace='default',
@@ -88,12 +95,16 @@ def create_from_dict(k8s_client, data, verbose=False, namespace='default',
         the yaml file already contains a namespace definition
         this parameter has no effect.
 
+    Returns:
+        The created kubernetes API objects.
+
     Raises:
         FailToCreateError which holds list of `client.rest.ApiException`
         instances for each object that failed to create.
     """
     # If it is a list type, will need to iterate its items
     api_exceptions = []
+    k8s_objects = []
 
     if "List" in data["kind"]:
         # Could be "List" or "Pod/Service/...List"
@@ -106,16 +117,18 @@ def create_from_dict(k8s_client, data, verbose=False, namespace='default',
                 yml_object["apiVersion"] = data["apiVersion"]
                 yml_object["kind"] = kind
             try:
-                create_from_yaml_single_item(
+                created = create_from_yaml_single_item(
                     k8s_client, yml_object, verbose, namespace=namespace,
                     **kwargs)
+                k8s_objects.append(created)
             except client.rest.ApiException as api_exception:
                 api_exceptions.append(api_exception)
     else:
         # This is a single object. Call the single item method
         try:
-            create_from_yaml_single_item(
+            created = create_from_yaml_single_item(
                 k8s_client, data, verbose, namespace=namespace, **kwargs)
+            k8s_objects.append(created)
         except client.rest.ApiException as api_exception:
             api_exceptions.append(api_exception)
 
@@ -123,6 +136,7 @@ def create_from_dict(k8s_client, data, verbose=False, namespace='default',
     if api_exceptions:
         raise FailToCreateError(api_exceptions)
 
+    return k8s_objects
 
 def create_from_yaml_single_item(
         k8s_client, yml_object, verbose=False, **kwargs):
@@ -160,6 +174,7 @@ def create_from_yaml_single_item(
         if hasattr(resp, 'status'):
             msg += " status='{0}'".format(str(resp.status))
         print(msg)
+    return resp
 
 
 class FailToCreateError(Exception):

--- a/kubernetes/utils/create_from_yaml.py
+++ b/kubernetes/utils/create_from_yaml.py
@@ -138,6 +138,7 @@ def create_from_dict(k8s_client, data, verbose=False, namespace='default',
 
     return k8s_objects
 
+
 def create_from_yaml_single_item(
         k8s_client, yml_object, verbose=False, **kwargs):
     group, _, version = yml_object["apiVersion"].partition("/")


### PR DESCRIPTION
It would be much convenient if the created kubernetes API objects could be returned, especially when the source is opequa yaml file.

Seems that there's no reason for not returning those results.