### PR TITLE
Document a breaking change in the default configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Kubernetes API Version: 1.16.14
 
 Kubernetes API Version: 1.16.14
 
+**Breaking Change:**
+
+- `kubernetes.config.Configuration()` will now return the default "initial" configuration, `kubernetes.config.Configuration.get_default_copy()` will return the default configuration if there is a default set via `Configuration.set_default(c)`, otherwise, it will also return the default "initial" configuration. [OpenAPITools/openapi-generator#4485](https://github.com/OpenAPITools/openapi-generator/pull/4485), [OpenAPITools/openapi-generator#5315](https://github.com/OpenAPITools/openapi-generator/pull/5315)
+
 **API Change:**
 
 - Resolve regression in metadata.managedFields handling in update/patch requests submitted by older API clients ([#91748](https://github.com/kubernetes/kubernetes/pull/91748), [@apelisse](https://github.com/apelisse)) [SIG API Machinery and Testing]

--- a/kubernetes/test/test_configuration.py
+++ b/kubernetes/test/test_configuration.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+
+import unittest
+
+from kubernetes.client import Configuration
+
+class TestConfiguration(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        # reset Configuration
+        Configuration.set_default(None)
+
+    def testConfiguration(self):
+        # check that different instances use different dictionaries
+        c1 = Configuration()
+        c2 = Configuration()
+        self.assertNotEqual(id(c1.api_key), id(c2.api_key))
+        self.assertNotEqual(id(c1.api_key_prefix), id(c2.api_key_prefix))
+
+    def testDefaultConfiguration(self):
+        # prepare default configuration
+        c1 = Configuration(host="example.com")
+        c1.debug = True
+        Configuration.set_default(c1)
+
+        # get default configuration
+        c2 = Configuration.get_default_copy()
+        self.assertEqual(c2.host, "example.com")
+        self.assertTrue(c2.debug)
+
+        self.assertNotEqual(id(c1.api_key), id(c2.api_key))
+        self.assertNotEqual(id(c1.api_key_prefix), id(c2.api_key_prefix))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
xref: https://github.com/kubernetes-client/python/issues/1284, https://github.com/OpenAPITools/openapi-generator/pull/4485, https://github.com/OpenAPITools/openapi-generator/pull/5315

Document a breaking change of `kubernetes.config.Configuration()` that exists since v12.0.0a1. Add a unit test that asserts the behavior. 

Special notes: 
1. The upstream change fixed a bug in different configuration objects unexpectedly sharing a common dict, but it broke the use case where people use `Configuration()` to easily access one global configuration. 
2. Not sure if the test folder gets wiped when we regenerate the client. If so, we may need to carry a patch, or find another place to host it. 
3. I looked at python-base and found the only place we use `Configuration()` is [_refresh_oidc](https://github.com/kubernetes-client/python-base/blob/2da2b981ca806b25487ad92d01a2164815c18517/config/kube_config.py#L413). The client doesn't rely on the default configuration. 