### PR TITLE
Update pyyaml from 3.1.2 to 5.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi>=14.05.14 # MPL
 six>=1.9.0  # MIT
 python-dateutil>=2.5.3  # BSD
 setuptools>=21.0.0  # PSF/ZPL
-pyyaml>=3.12  # MIT
+pyyaml>=5.4.1  # MIT
 google-auth>=1.0.1  # Apache-2.0
 ipaddress>=1.0.17;python_version=="2.7"  # PSF
 websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.* # LGPLv2+


### PR DESCRIPTION
5.3.1 fixed partially vulnerabilities disclosed in CVE-2020-1747.
A complete fix was debated at yaml/pyyaml#420 and eventually got patched in 5.4.1

Changeset: https://github.com/yaml/pyyaml/compare/3.12...5.4.1

I skimmed through the changeset and didn't see any apparent breaking changes.
But I will go through that in more detail. Putting a hold due to the same.

/hold