### PR TITLE
Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial
+dist: bionic
 services:
 - docker
 
@@ -13,9 +13,16 @@ jobs:
   include:
   - stage: verify-tag
     python: 3.7
+    arch: ppc64le
     script: >
       [ "v$(python -c 'from scripts.constants import CLIENT_VERSION; print(CLIENT_VERSION)')" == "${TRAVIS_TAG}" ] &&
       [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(([ab]|dev|rc)[0-9]+)?$ ]]
+  - stage: verify-tag
+    python: 3.7
+    script: >
+      [ "v$(python -c 'from scripts.constants import CLIENT_VERSION; print(CLIENT_VERSION)')" == "${TRAVIS_TAG}" ] &&
+      [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(([ab]|dev|rc)[0-9]+)?$ ]]
+
   - stage: test
     python: 2.7
     env: TOXENV=update-pycodestyle
@@ -49,6 +56,47 @@ jobs:
     env: TOXENV=py39-functional
   - stage: deploy
     script: skip
+    deploy:
+      provider: pypi
+      user: __token__
+      password:
+        secure: gY5Rixj7mWHC9XP5qV5DfWGdX4ZVwCEUElnQA2OeIg235I3eMBqRFM4Q/SKwAG2DzgIWNKsXXVQsZHp7BAjWFMFVQloiU7zohuBRToJUim9U1RaqAjUIr4OU7JPtXenAl5zyyBdywvJiG8UZ4wmt1DBYtdpozQvOwDXvOxNTmElKh5mfDhiSsipmFr2198NtIhiRVC+CZliZsi6osUkt+G6yl9CW+SJU3otgzdaS+VBP26HO0kWHMJiDKvQoIl/Q50IqJUWieFhCLh7lSV71VNVEmM4bMcYK8cAv3zMZHo6REKHF7xrF5tzYMXqpmEGt6L798d2H4BISr6BIlYgiYCatjyE9hxih9iBzGs0XaGUUFD8u1iuzOQI76a5dapG/DixQrGD2o9Gn/Qw6Zp9USIuKZSWUn5hSobwxJUKVNy+afpaJNQUb2W9Hj+jMXAnBDodCzo3nu+QF8GN72cmk3uqVyKUVABtI4kNe3qcEx3DyKfoh7aqJrgydeaRwESKuZ41l5CA+vqXSbbNW8z1MYDYgVdwEyRFsLg6aQk5pPsxuiILaaGy13TUndhuC+GuKcW6wCDf6WpUAwwGAF8+sz4hZ1pfSUdE3F8nfDBW3Bv+G9cB/cKkWJ2vOd9httRrvir8qUc/xPP5aW4pacnfNCQ04Iep/k4PCAdYJDtVGhCY=
+      skip_existing: true
+      on:
+        tags: true
+        repo: kubernetes-client/python
+      distributions: sdist bdist_wheel
+
+  - stage: test
+    python: 2.7
+    env: TOXENV=update-pycodestyle
+    arch: ppc64le
+  - python: 3.7
+    env: TOXENV=docs
+    arch: ppc64le
+  - python: 2.7
+    env: TOXENV=coverage,codecov
+    arch: ppc64le
+  - python: 2.7
+    env: TOXENV=py27
+    arch: ppc64le
+  - python: 3.5
+    env: TOXENV=py35
+    arch: ppc64le
+  - python: 3.6
+    env: TOXENV=py36
+    arch: ppc64le
+  - python: 3.7
+    env: TOXENV=py37
+    arch: ppc64le
+  - python: 3.8
+    env: TOXENV=py38
+  - python: 3.9
+    env: TOXENV=py39
+    arch: ppc64le
+  - stage: deploy
+    script: skip
+    arch: ppc64le
     deploy:
       provider: pypi
       user: __token__


### PR DESCRIPTION

I am working for IBM to port cpu arch ppc64le for open sources.

This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro 
on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.


This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and 
ISVs, and while we don't use this package directly,we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or 
third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.

Please help to verify and merge.