### PR TITLE
Fix broken link of docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,5 @@ target/
 
 # created by sphinx documentation build
 doc/source/README.md
+doc/source/CONTRIBUTING.md
 doc/_build

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -11,10 +11,10 @@ Deployments
 Here is a simple usage of creating a deployment from a yaml file:
 
 
-.. literalinclude:: ../../examples/create_deployment.py
+.. literalinclude:: ../../examples/deployment_create.py
 
 
 The following example demostrates how to create, update and delete deployments
 without the need to read a file from the disk:
 
-.. literalinclude:: ../../examples/deployment_examples.py
+.. literalinclude:: ../../examples/deployment_crud.py


### PR DESCRIPTION
Minor: 
* I found some links to file are broken when I going through the docs, probably due to file renaming.
* When I fixed the link and regenerate the docs, I found the `CONTRIBUTING.md` which is copied to `python/source/` is not added to `.gitignore`.