### PR TITLE
e2e: use labels for configmap api; wait for default service account creation

### DIFF
--- a/kubernetes/e2e_test/test_client.py
+++ b/kubernetes/e2e_test/test_client.py
@@ -443,6 +443,7 @@ class TestClient(unittest.TestCase):
             "apiVersion": "v1",
             "metadata": {
                 "name": name,
+                "labels": {"e2e-tests": "true"},
             },
             "data": {
                 "config.json": "{\"command\":\"/usr/bin/mysqld_safe\"}",
@@ -466,7 +467,7 @@ class TestClient(unittest.TestCase):
         resp = api.delete_namespaced_config_map(
             name=name, body={}, namespace='default')
 
-        resp = api.list_namespaced_config_map('default', pretty=True)
+        resp = api.list_namespaced_config_map('default', pretty=True, label_selector="e2e-tests=true")
         self.assertEqual([], resp.items)
 
     def test_node_apis(self):

--- a/kubernetes/e2e_test/test_watch.py
+++ b/kubernetes/e2e_test/test_watch.py
@@ -32,6 +32,7 @@ def config_map_with_value(name, value):
         "kind": "ConfigMap",
         "metadata": {
             "name": name,
+            "labels": {"e2e-tests": "true"},
         },
         "data": {
             "key": value,
@@ -57,7 +58,7 @@ class TestClient(unittest.TestCase):
             body=configmap_a, namespace='default')
 
         # list all configmaps and extract the resource version
-        resp = api.list_namespaced_config_map('default')
+        resp = api.list_namespaced_config_map('default', label_selector="e2e-tests=true")
         rv = resp.metadata.resource_version
 
         # create another configmap
@@ -73,7 +74,7 @@ class TestClient(unittest.TestCase):
 
         # delete all configmaps
         api.delete_collection_namespaced_config_map(
-            namespace='default')
+            namespace='default', label_selector="e2e-tests=true")
 
         w = watch.Watch()
         # expect to observe all events happened after the initial LIST
@@ -83,7 +84,8 @@ class TestClient(unittest.TestCase):
         for event in w.stream(api.list_namespaced_config_map,
                               namespace='default',
                               resource_version=rv,
-                              timeout_seconds=5):
+                              timeout_seconds=5,
+                              label_selector="e2e-tests=true"):
             self.assertEqual(event['type'], expect[i])
             # Kubernetes doesn't guarantee the order of the two objects
             # being deleted


### PR DESCRIPTION
The [Bound Service Account Tokens](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/1205-bound-service-account-tokens/README.md) feature creates a configmap `kube-root-ca.crt` in every namespace. Use a label to select the test objects we create. 

Also wait for the default service account to be created before creating pods that need it. 

/hold
wait for the tests to pass

The submodule update contains two commits, which do not require CHANGELOG change:
1. add labels to `dynamic/test_client.py::TestDynamicClient::test_configmap_apis`
2. add Python 3.9 to build

ref https://github.com/kubernetes-client/python-base/pull/222, https://github.com/kubernetes-client/python/pull/1347