### PR TITLE
Added kubernetes.leaderelection in packages list to fix import error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
               'kubernetes.watch', 'kubernetes.client.api',
               'kubernetes.stream', 'kubernetes.client.models',
               'kubernetes.utils', 'kubernetes.client.apis',
-              'kubernetes.dynamic'],
+              'kubernetes.dynamic', 'kubernetes.leaderelection'],
     include_package_data=True,
     long_description="Python client for kubernetes http://kubernetes.io/",
     classifiers=[


### PR DESCRIPTION
…ed 'kubernetes.leaderelection' error

To reproduce: Make sure to create a file outside of checked out python repo directory.
$ cat hello_k8s.py
import kubernetes

kubernetes.config.load_kube_config()

k8s = kubernetes.client.CoreV1Api()
print("Listing pods with their IPs:")
ret = k8s.list_pod_for_all_namespaces(watch=False)
for i in ret.items:
    print("%s\t%s\t%s" % (i.status.pod_ip, i.metadata.namespace, i.metadata.name))

python hello_k8s.py
Traceback (most recent call last):
  File "hello_k8s.py", line 1, in <module>
    import kubernetes
  File "<frozen zipimport>", line 259, in load_module
  File "anaconda3/lib/python3.8/site-packages/kubernetes-17.0.0_snapshot-py3.8.egg/kubernetes/__init__.py", line 25, in <module>
ModuleNotFoundError: No module named 'kubernetes.leaderelection'