### PR TITLE
Delete kubernetes resources from yaml files , solves #940

### DIFF
--- a/kubernetes/e2e_test/test_utils.py
+++ b/kubernetes/e2e_test/test_utils.py
@@ -439,6 +439,30 @@ class TestUtils(unittest.TestCase):
         app_api.delete_namespaced_deployment(
             name="mock", namespace=self.test_namespace, body={})
 
+    def test_delete_namespace_from_yaml(self):
+        """
+        Should be able to delete a namespace
+        Create namespace from file first and ensure it is created
+        """
+        k8s_client = client.api_client.ApiClient(configuration=self.config)
+        time.sleep(120)
+        utils.create_from_yaml(
+            k8s_client, self.path_prefix + "core-namespace.yaml")
+        core_api = client.CoreV1Api(k8s_client)
+        nmsp = core_api.read_namespace(name="development")
+        self.assertIsNotNone(nmsp)
+        """
+        Delete namespace from yaml
+        """
+        utils.delete_from_yaml(k8s_client, self.path_prefix + "core-namespace.yaml")
+        time.sleep(120)
+        namespace_status=False
+        try:
+            response=core_api.read_namespace(name="development")
+            namespace_status=True
+        except Exception as e:
+            self.assertFalse(namespace_status)
+        self.assertFalse(namespace_status)
     
     def test_delete_apps_deployment_from_yaml(self):
         """
@@ -458,6 +482,7 @@ class TestUtils(unittest.TestCase):
         """
         utils.delete_from_yaml(k8s_client, self.path_prefix + "apps-deployment.yaml")
         deployment_status=False
+        time.sleep(120)
         try:
             response=app_api.read_namespaced_deployment(name="nginx-app",namespace="default")
             deployment_status=True
@@ -484,38 +509,13 @@ class TestUtils(unittest.TestCase):
         utils.delete_from_yaml(
             k8s_client, self.path_prefix + "core-service.yaml")
         service_status=False
+        time.sleep(120)
         try:
             response = core_api.read_namespaced_service(name="my-service",namespace="default")
             service_status=True 
         except Exception as e:
             self.assertFalse(service_status)
         self.assertFalse(service_status)
-
-    def test_delete_namespace_from_yaml(self):
-        """
-        Should be able to delete a namespace
-        Create namespace from file first and ensure it is created
-        """
-        k8s_client = client.api_client.ApiClient(configuration=self.config)
-        time.sleep(120)
-        utils.create_from_yaml(
-            k8s_client, self.path_prefix + "core-namespace.yaml")
-        core_api = client.CoreV1Api(k8s_client)
-        nmsp = core_api.read_namespace(name="development")
-        self.assertIsNotNone(nmsp)
-        """
-        Delete namespace from yaml
-        """
-        utils.delete_from_yaml(k8s_client, self.path_prefix + "core-namespace.yaml")
-        time.sleep(120)
-        namespace_status=False
-        try:
-            response=core_api.read_namespace(name="development")
-            namespace_status=True
-        except Exception as e:
-            self.assertFalse(namespace_status)
-        self.assertFalse(namespace_status)
-
     
     def test_delete_pod_from_yaml(self):
         """
@@ -564,6 +564,7 @@ class TestUtils(unittest.TestCase):
         utils.delete_from_yaml(
             k8s_client, self.path_prefix + "rbac-role.yaml")
         rbac_role_status=False
+        time.sleep(120)
         try:
             response = rbac_api.read_namespaced_role(
             name="pod-reader", namespace="default")
@@ -591,6 +592,7 @@ class TestUtils(unittest.TestCase):
             k8s_client, self.path_prefix + "rbac-role.yaml", verbose=True)
         
         rbac_role_status=False
+        time.sleep(120)
         try:
             response=rbac_api.read_namespaced_role(
             name="pod-reader", namespace="default")
@@ -625,6 +627,7 @@ class TestUtils(unittest.TestCase):
             k8s_client, self.path_prefix + "multi-resource.yaml")
         svc_status=False
         replication_status=False
+        time.sleep(120)
         try:
             resp_svc= core_api.read_namespaced_service(name="mock",
                                                namespace="default")

--- a/kubernetes/utils/__init__.py
+++ b/kubernetes/utils/__init__.py
@@ -14,6 +14,6 @@
 
 from __future__ import absolute_import
 
-from .create_from_yaml import (FailToCreateError, create_from_dict,
-                               create_from_yaml)
+from .operate_from_yaml import (FailToExecuteError, create_from_yaml,
+                                delete_from_yaml, operate_from_dict)
 from .quantity import parse_quantity

--- a/kubernetes/utils/delete_from_yaml.py
+++ b/kubernetes/utils/delete_from_yaml.py
@@ -1,0 +1,163 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import re
+from os import path
+
+import yaml
+
+from kubernetes import client
+
+
+def delete_from_yaml(k8s_client, yaml_file, verbose=False,
+                     namespace="default", **kwargs):
+    """
+    Delete a resource from a yaml file.
+    Input:
+    yaml_file: string. Contains the path to yaml file.
+    k8s_client: an ApiClient object, initialized with the client args.
+    verbose: If True, print confirmation from the create action.
+        Default is False.
+    namespace: string. Contains the namespace to create all
+        resources inside. The namespace must preexist otherwise
+        the resource creation will fail. If the API object in
+        the yaml file already contains a namespace definition
+        this parameter has no effect.
+    Available parameters for creating <kind>:
+    :param async_req bool
+    :param str pretty: If 'true', then the output is pretty printed.
+    :param str dry_run: When present, indicates that modifications
+        should not be persisted. An invalid or unrecognized dryRun
+        directive will result in an error response and no further
+        processing of the request.
+        Valid values are: - All: all dry run stages will be processed
+    Raises:
+        FailToDeleteError which holds list of `client.rest.ApiException`
+        instances for each object that failed to delete.
+    """
+    with open(path.abspath(yaml_file)) as f:
+        yml_document_all = yaml.safe_load_all(f)
+        failures = []
+        for yml_document in yml_document_all:
+            try:
+                delete_from_dict(k8s_client, yml_document, verbose,
+                                 namespace=namespace, **kwargs)
+            except FailToDeleteError as failure:
+                failures.extend(failure.api_exceptions)
+        if failures:
+            raise FailToDeleteError(failures)
+
+
+def delete_from_dict(k8s_client, yml_document, verbose,
+                     namespace="default", **kwargs):
+    """
+    Delete a kubernetes resource from a dictionary containing valid kubernetes
+    API object (i.e. List, Service, etc).
+    Input:
+    k8s_client: an ApiClient object, initialized with the client args.
+    yml_document: a dictionary holding valid kubernetes objects
+    verbose: If True, print confirmation from the create action.
+        Default is False.
+    namespace: string. Contains the namespace to create all
+        resources inside. The namespace must preexist otherwise
+        the resource creation will fail. If the API object in
+        the yaml file already contains a namespace definition
+        this parameter has no effect.
+    Raises:
+        FailToDeleteError which holds list of `client.rest.ApiException`
+        instances for each object that failed to create.
+    """
+    api_exceptions = []
+    if "List" in yml_document["kind"]:
+        kind = yml_document["kind"].replace("List", "")
+        for yml_doc in yml_document["items"]:
+            if kind != "":
+                yml_doc["apiVersion"] = yml_document["apiVersion"]
+                yml_doc["kind"] = kind
+            try:
+                delete_from_yaml_single_item(
+                    k8s_client, yml_doc, verbose, namespace=namespace, **kwargs
+                )
+            except client.rest.ApiException as api_exception:
+                api_exceptions.append(api_exception)
+    else:
+        try:
+            delete_from_yaml_single_item(
+                k8s_client, yml_document, verbose,
+                namespace=namespace, **kwargs
+            )
+        except client.rest.ApiException as api_exception:
+            api_exceptions.append(api_exception)
+
+    if api_exceptions:
+        raise FailToDeleteError(api_exceptions)
+
+
+def delete_from_yaml_single_item(k8s_client,
+                                 yml_document, verbose=False, **kwargs):
+    # get group and version from apiVersion
+    group, _, version = yml_document["apiVersion"].partition("/")
+    if version == "":
+        version = group
+        group = "core"
+    # Take care for the case e.g. api_type is "apiextensions.k8s.io"
+    group = "".join(group.rsplit(".k8s.io", 1))
+    # convert group name from DNS subdomain format to
+    # python class name convention
+    group = "".join(word.capitalize() for word in group.split('.'))
+    func = "{0}{1}Api".format(group, version.capitalize())
+    k8s_api = getattr(client, func)(k8s_client)
+    kind = yml_document["kind"]
+    kind = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', kind)
+    kind = re.sub('([a-z0-9])([A-Z])', r'\1_\2', kind).lower()
+    if hasattr(k8s_api, "create_namespaced_{0}".format(kind)):
+        if "namespace" in yml_document["metadata"]:
+            namespace = yml_document["metadata"]["namespace"]
+            kwargs["namespace"] = namespace
+        name = yml_document["metadata"]["name"]
+        res = getattr(k8s_api, "delete_namespaced_{}".format(kind))(
+            name=name,
+            body=client.V1DeleteOptions(propagation_policy="Background",
+                                        grace_period_seconds=5), **kwargs)
+    else:
+        # get name of object to delete
+        name = yml_document["metadata"]["name"]
+        kwargs.pop('namespace', None)
+        res = getattr(k8s_api, "delete_{}".format(kind))(
+            name=name,
+            body=client.V1DeleteOptions(propagation_policy="Background",
+                                        grace_period_seconds=5), **kwargs)
+    if verbose:
+        msg = "{0} deleted.".format(kind)
+        if hasattr(res, 'status'):
+            msg += " status='{0}'".format(str(res.status))
+        print(msg)
+
+
+class FailToDeleteError(Exception):
+    """
+    An exception class for handling error if an error occurred when
+    handling a yaml file during deletion of the resource.
+    """
+
+    def __init__(self, api_exceptions):
+        self.api_exceptions = api_exceptions
+
+    def __str__(self):
+        msg = ""
+        for api_exception in self.api_exceptions:
+            msg += "Error from server ({0}):{1}".format(
+                api_exception.reason, api_exception.body)
+        return msg

--- a/kubernetes/utils/operate_from_yaml.py
+++ b/kubernetes/utils/operate_from_yaml.py
@@ -21,21 +21,21 @@ import yaml
 from kubernetes import client
 
 
-def create_from_yaml(k8s_client, yaml_file,yaml_objects=None ,verbose=False,
+def create_from_yaml(k8s_client, yaml_file=None,yaml_objects=None ,verbose=False,
                      namespace="default", **kwargs):
     operation = "create"
     operate_from_yaml(k8s_client, yaml_file, operation,yaml_objects,verbose=False,
                       namespace="default", **kwargs)
 
 
-def delete_from_yaml(k8s_client, yaml_file,yaml_objects=None ,verbose=False,
+def delete_from_yaml(k8s_client, yaml_file=None,yaml_objects=None ,verbose=False,
                      namespace="default", **kwargs):
     operation = "delete"
     operate_from_yaml(k8s_client, yaml_file, operation,yaml_objects,verbose=False,
                       namespace="default", **kwargs)
 
 
-def operate_from_yaml(k8s_client, yaml_file, operation,yaml_objects=None,verbose=False,
+def operate_from_yaml(k8s_client, yaml_file=None, operation=None,yaml_objects=None,verbose=False,
                       namespace="default", **kwargs):
     """
     Input:
@@ -60,7 +60,7 @@ def operate_from_yaml(k8s_client, yaml_file, operation,yaml_objects=None,verbose
         FailToExecuteError which holds list of `client.rest.ApiException`
         instances for each object that failed to delete.
     """
-    def create_with(objects):
+    def operate_with(objects):
         failures = []
         k8s_objects = []
         for yml_document in objects:
@@ -78,11 +78,11 @@ def operate_from_yaml(k8s_client, yaml_file, operation,yaml_objects=None,verbose
         return k8s_objects
     if yaml_objects:
         yml_document_all = yaml_objects
-        return create_with(yml_document_all)
+        return operate_with(yml_document_all)
     elif yaml_file:
         with open(path.abspath(yaml_file)) as f:
             yml_document_all = yaml.safe_load_all(f)
-            return create_with(yml_document_all)
+            return operate_with(yml_document_all)
     else:
         raise ValueError(
             'One of `yaml_file` or `yaml_objects` arguments must be provided')

--- a/kubernetes/utils/operate_from_yaml.py
+++ b/kubernetes/utils/operate_from_yaml.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Kubernetes Authors.
+# Copyright 2021 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,9 @@
 
 
 import re
-from os import path
-
 import yaml
 
+from os import path
 from kubernetes import client
 
 

--- a/kubernetes/utils/operate_from_yaml.py
+++ b/kubernetes/utils/operate_from_yaml.py
@@ -1,0 +1,230 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import re
+from os import path
+
+import yaml
+
+from kubernetes import client
+
+
+def create_from_yaml(k8s_client, yaml_file,yaml_objects=None ,verbose=False,
+                     namespace="default", **kwargs):
+    operation = "create"
+    operate_from_yaml(k8s_client, yaml_file, operation,yaml_objects,verbose=False,
+                      namespace="default", **kwargs)
+
+
+def delete_from_yaml(k8s_client, yaml_file,yaml_objects=None ,verbose=False,
+                     namespace="default", **kwargs):
+    operation = "delete"
+    operate_from_yaml(k8s_client, yaml_file, operation,yaml_objects,verbose=False,
+                      namespace="default", **kwargs)
+
+
+def operate_from_yaml(k8s_client, yaml_file, operation,yaml_objects=None,verbose=False,
+                      namespace="default", **kwargs):
+    """
+    Input:
+    yaml_file: string. Contains the path to yaml file.
+    k8s_client: an ApiClient object, initialized with the client args.
+    verbose: If True, print confirmation from the create action.
+        Default is False.
+    namespace: string. Contains the namespace to create all
+        resources inside. The namespace must preexist otherwise
+        the resource creation will fail. If the API object in
+        the yaml file already contains a namespace definition
+        this parameter has no effect.
+    Available parameters for creating <kind>:
+    :param async_req bool
+    :param str pretty: If 'true', then the output is pretty printed.
+    :param str dry_run: When present, indicates that modifications
+        should not be persisted. An invalid or unrecognized dryRun
+        directive will result in an error response and no further
+        processing of the request.
+        Valid values are: - All: all dry run stages will be processed
+    Raises:
+        FailToExecuteError which holds list of `client.rest.ApiException`
+        instances for each object that failed to delete.
+    """
+    def create_with(objects):
+        failures = []
+        k8s_objects = []
+        for yml_document in objects:
+            if yml_document is None:
+                continue
+            try:
+                created = operate_from_dict(k8s_client, yml_document,operation, verbose,
+                                           namespace=namespace,
+                                           **kwargs)
+                k8s_objects.append(created)
+            except FailToExecuteError as failure:
+                failures.extend(failure.api_exceptions)
+        if failures:
+            raise FailToExecuteError(failures)
+        return k8s_objects
+    if yaml_objects:
+        yml_document_all = yaml_objects
+        return create_with(yml_document_all)
+    elif yaml_file:
+        with open(path.abspath(yaml_file)) as f:
+            yml_document_all = yaml.safe_load_all(f)
+            return create_with(yml_document_all)
+    else:
+        raise ValueError(
+            'One of `yaml_file` or `yaml_objects` arguments must be provided')
+
+def operate_from_dict(k8s_client, yml_document, operation, verbose,
+                      namespace="default", **kwargs):
+    """
+    Perform an operation kubernetes resource from a dictionary containing valid kubernetes
+    API object (i.e. List, Service, etc).
+    Input:
+    k8s_client: an ApiClient object, initialized with the client args.
+    yml_document: a dictionary holding valid kubernetes objects
+    verbose: If True, print confirmation from the create action.
+        Default is False.
+    namespace: string. Contains the namespace to create all
+        resources inside. The namespace must preexist otherwise
+        the resource creation will fail. If the API object in
+        the yaml file already contains a namespace definition
+        this parameter has no effect.
+    Raises:
+        FailToExecuteError which holds list of `client.rest.ApiException`
+        instances for each object that failed to create.
+    """
+    api_exceptions = []
+    if "List" in yml_document["kind"]:
+        kind = yml_document["kind"].replace("List", "")
+        for yml_doc in yml_document["items"]:
+            if kind != "":
+                yml_doc["apiVersion"] = yml_document["apiVersion"]
+                yml_doc["kind"] = kind
+            try:
+                operate_from_yaml_single_item(
+                    k8s_client,
+                    yml_doc,
+                    operation,
+                    verbose,
+                    namespace=namespace,
+                    **kwargs)
+            except client.rest.ApiException as api_exception:
+                api_exceptions.append(api_exception)
+    else:
+        try:
+            operate_from_yaml_single_item(
+                k8s_client, yml_document, operation, verbose,
+                namespace=namespace, **kwargs
+            )
+        except client.rest.ApiException as api_exception:
+            api_exceptions.append(api_exception)
+
+    if api_exceptions:
+        raise FailToExecuteError(api_exceptions)
+
+
+def operate_from_yaml_single_item(
+        k8s_client,
+        yml_document,
+        operation,
+        verbose=False,
+        namespace="default",
+        **kwargs):
+    # get group and version from apiVersion
+    group, _, version = yml_document["apiVersion"].partition("/")
+    if version == "":
+        version = group
+        group = "core"
+    # Take care for the case e.g. api_type is "apiextensions.k8s.io"
+    group = "".join(group.rsplit(".k8s.io", 1))
+    # convert group name from DNS subdomain format to
+    # python class name convention
+    group = "".join(word.capitalize() for word in group.split('.'))
+    func = "{0}{1}Api".format(group, version.capitalize())
+    k8s_api = getattr(client, func)(k8s_client)
+    kind = yml_document["kind"]
+    kind = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', kind)
+    kind = re.sub('([a-z0-9])([A-Z])', r'\1_\2', kind).lower()
+    if operation == "create":
+        resp = create_k8s_object(
+            k8s_api, yml_document, kind, namespace=namespace)
+        if verbose:
+            msg = "{0} created.".format(kind)
+            if hasattr(resp, 'status'):
+                msg += " status='{0}'".format(str(resp.status))
+            print(msg)
+    elif operation == "delete":
+        resp = delete_k8s_object(
+            k8s_api, yml_document, kind, namespace=namespace)
+        if verbose:
+            msg = "{0} deleted.".format(kind)
+            if hasattr(resp, 'status'):
+                msg += " status='{0}'".format(str(resp.status))
+            print(msg)
+
+
+def create_k8s_object(k8s_api, yml_document, kind, **kwargs):
+
+    if hasattr(k8s_api, "create_namespaced_{0}".format(kind)):
+        if "namespace" in yml_document["metadata"]:
+            namespace = yml_document["metadata"]["namespace"]
+            kwargs['namespace'] = namespace
+        resp = getattr(k8s_api, "create_namespaced_{0}".format(kind))(
+            body=yml_document, **kwargs)
+    else:
+        kwargs.pop('namespace', None)
+        resp = getattr(k8s_api, "create_{0}".format(kind))(
+            body=yml_document, **kwargs)
+    return resp
+
+
+def delete_k8s_object(k8s_api, yml_document, kind, **kwargs):
+
+    if hasattr(k8s_api, "create_namespaced_{0}".format(kind)):
+        if "namespace" in yml_document["metadata"]:
+            namespace = yml_document["metadata"]["namespace"]
+            kwargs["namespace"] = namespace
+        name = yml_document["metadata"]["name"]
+        resp = getattr(k8s_api, "delete_namespaced_{}".format(kind))(
+            name=name,
+            body=client.V1DeleteOptions(propagation_policy="Background",
+                                        grace_period_seconds=5), **kwargs)
+    else:
+        # get name of object to delete
+        name = yml_document["metadata"]["name"]
+        kwargs.pop('namespace', None)
+        resp = getattr(k8s_api, "delete_{}".format(kind))(
+            name=name,
+            body=client.V1DeleteOptions(propagation_policy="Background",
+                                        grace_period_seconds=5), **kwargs)
+    return resp
+
+
+class FailToExecuteError(Exception):
+    """
+    An exception class for handling error if an error occurred when
+    handling a yaml file during creation or deletion of the resource.
+    """
+
+    def __init__(self, api_exceptions):
+        self.api_exceptions = api_exceptions
+
+    def __str__(self):
+        msg = ""
+        for api_exception in self.api_exceptions:
+            msg += "Error from server ({0}):{1}".format(
+                api_exception.reason, api_exception.body)
+        return msg


### PR DESCRIPTION
This is a method to delete kubernetes resources using the yaml files . It is similar to the method create_from_yaml but for deleting kubernetes resources .
It can be used to any type pf resource deployment , pod , service etc.
Fixes #940

create_from_yaml creates kubernetes objects like deployments,serivces,ingress etc from the given yml files , the delete_from_yaml method can be used to remove/delete those objects from the same yml files in the given cluster for any namespace