### PR TITLE
API client shows error when metadata is ignored

### DIFF
--- a/kubernetes/docs/V1HorizontalPodAutoscaler.md
+++ b/kubernetes/docs/V1HorizontalPodAutoscaler.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **api_version** | **str** | APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources | [optional] 
 **kind** | **str** | Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the kubernetes.client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds | [optional] 
-**metadata** | [**V1ObjectMeta**](V1ObjectMeta.md) |  | [optional] 
+**metadata** | [**V1ObjectMeta**](V1ObjectMeta.md) |  | 
 **spec** | [**V1HorizontalPodAutoscalerSpec**](V1HorizontalPodAutoscalerSpec.md) |  | [optional] 
 **status** | [**V1HorizontalPodAutoscalerStatus**](V1HorizontalPodAutoscalerStatus.md) |  | [optional] 
 


### PR DESCRIPTION
"message": "HorizontalPodAutoscaler.autoscaling \"\" is invalid: metadata.name: Required value: name or generateName is required",