### PR TITLE
Make job_crud example print the correct job status after job creation

### DIFF
--- a/examples/job_crud.py
+++ b/examples/job_crud.py
@@ -20,6 +20,8 @@ from os import path
 
 import yaml
 
+from time import sleep
+
 from kubernetes import client, config
 
 JOB_NAME = "pi"
@@ -53,7 +55,16 @@ def create_job(api_instance, job):
     api_response = api_instance.create_namespaced_job(
         body=job,
         namespace="default")
-    print("Job created. status='%s'" % str(api_response.status))
+    # Need to wait for a second for the job status to update
+    sleep(1)
+    print("Job created. status='%s'" % str(get_job_status(api_instance)))
+
+
+def get_job_status(api_instance):
+    api_response = api_instance.read_namespaced_job_status(
+        name=JOB_NAME,
+        namespace="default")
+    return api_response.status
 
 
 def update_job(api_instance, job):

--- a/examples/job_crud.py
+++ b/examples/job_crud.py
@@ -55,7 +55,8 @@ def create_job(api_instance, job):
     api_response = api_instance.create_namespaced_job(
         body=job,
         namespace="default")
-    print("Job created. status='%s'" % str(get_job_status(api_instance)))
+    print("Job created. status='%s'" % str(api_response.status))
+    print("Job status='%s'" % str(get_job_status(api_instance)))
 
 
 def get_job_status(api_instance):
@@ -66,6 +67,7 @@ def get_job_status(api_instance):
             namespace="default")
         if api_response.status.succeeded is not None or api_response.status.failed is not None:
             job_completed = True
+        sleep(1)
     return api_response.status
 
 

--- a/examples/job_crud.py
+++ b/examples/job_crud.py
@@ -17,10 +17,9 @@ Creates, updates, and deletes a job object.
 """
 
 from os import path
-
-import yaml
-
 from time import sleep
+ 
+import yaml
 
 from kubernetes import client, config
 

--- a/examples/job_crud.py
+++ b/examples/job_crud.py
@@ -18,7 +18,7 @@ Creates, updates, and deletes a job object.
 
 from os import path
 from time import sleep
- 
+
 import yaml
 
 from kubernetes import client, config

--- a/examples/job_crud.py
+++ b/examples/job_crud.py
@@ -55,15 +55,17 @@ def create_job(api_instance, job):
     api_response = api_instance.create_namespaced_job(
         body=job,
         namespace="default")
-    # Need to wait for a second for the job status to update
-    sleep(1)
     print("Job created. status='%s'" % str(get_job_status(api_instance)))
 
 
 def get_job_status(api_instance):
-    api_response = api_instance.read_namespaced_job_status(
-        name=JOB_NAME,
-        namespace="default")
+    job_completed = False
+    while not job_completed:
+        api_response = api_instance.read_namespaced_job_status(
+            name=JOB_NAME,
+            namespace="default")
+        if api_response.status.succeeded is not None or api_response.status.failed is not None:
+            job_completed = True
     return api_response.status
 
 

--- a/examples/job_crud.py
+++ b/examples/job_crud.py
@@ -59,14 +59,14 @@ def create_job(api_instance, job):
     get_job_status(api_instance)
 
 
-
 def get_job_status(api_instance):
     job_completed = False
     while not job_completed:
         api_response = api_instance.read_namespaced_job_status(
             name=JOB_NAME,
             namespace="default")
-        if api_response.status.succeeded is not None or api_response.status.failed is not None:
+        if api_response.status.succeeded is not None or \
+                api_response.status.failed is not None:
             job_completed = True
         sleep(1)
         print("Job status='%s'" % str(api_response.status))

--- a/examples/job_crud.py
+++ b/examples/job_crud.py
@@ -56,7 +56,8 @@ def create_job(api_instance, job):
         body=job,
         namespace="default")
     print("Job created. status='%s'" % str(api_response.status))
-    print("Job status='%s'" % str(get_job_status(api_instance)))
+    get_job_status(api_instance)
+
 
 
 def get_job_status(api_instance):
@@ -68,7 +69,7 @@ def get_job_status(api_instance):
         if api_response.status.succeeded is not None or api_response.status.failed is not None:
             job_completed = True
         sleep(1)
-    return api_response.status
+        print("Job status='%s'" % str(api_response.status))
 
 
 def update_job(api_instance, job):


### PR DESCRIPTION
create_job function was not printing the current status of the job. Modified the create_job function to call read_namespaced_job_status in order to get the current job status