### PR TITLE
add update-submodule script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,72 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+
+1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
+2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
+https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
+3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
+4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
+5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
+-->
+
+#### What type of PR is this?
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+/kind design
+
+Optionally add one or more of the following kinds if applicable:
+/kind api-change
+/kind deprecation
+/kind failing-test
+/kind flake
+/kind regression
+-->
+
+#### What this PR does / why we need it:
+
+#### Which issue(s) this PR fixes:
+<!--
+*Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
+-->
+Fixes #
+
+#### Special notes for your reviewer:
+
+#### Does this PR introduce a user-facing change?
+<!--
+If no, just write "NONE" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+
+For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
+-->
+```release-note
+
+```
+
+#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
+
+<!--
+This section can be blank if this pull request does not require a release note.
+
+When adding links which point to resources within git repositories, like
+KEPs or supporting documentation, please reference a specific commit and avoid
+linking directly to the master branch. This ensures that links reference a
+specific point in time, rather than a document that may change over time.
+
+See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files
+
+Please use the following format for linking documentation:
+- [KEP]: <link>
+- [Usage]: <link>
+- [Other doc]: <link>
+-->
+```docs
+
+```

--- a/devel/submodules.md
+++ b/devel/submodules.md
@@ -26,4 +26,4 @@ If you changed [kubernetes-client/python-base](https://github.com/kubernetes-cli
 scripts/update-submodule.sh
 ```
 
-Create a commit "generated python-base update" and send a PR to the main repo.
+After the script finishes, please create a commit "generated python-base update" and send a PR to this repository.

--- a/devel/submodules.md
+++ b/devel/submodules.md
@@ -23,7 +23,7 @@ git submodule update --init
 If you changed [kubernetes-client/python-base](https://github.com/kubernetes-client/python-base) and want to pull your changes into this repo run this command:
 
 ```bash
-git submodule update --remote
+scripts/update-submodule.sh
 ```
 
-Once updated, you should create a new PR to commit changes to the repository.
+Create a commit "generated python-base update" and send a PR to the main repo.

--- a/scripts/update-submodule.sh
+++ b/scripts/update-submodule.sh
@@ -14,13 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 # Update python-base submodule and collect release notes.
 # Usage:
-#   scripts/update-submodule.sh
 #
-# Create a commit "generated python-base update" and send a PR to the main repo.
-# NOTE: not all python-base changes are user-facing, and you may want to remove
-# some of the non-user-facing release notes from CHANGELOG.md.
+#   $ scripts/update-submodule.sh
+#
+#   # To update the release notes for a specific release (e.g. v18.17.0a1):
+#   $ TARGET_RELEASE="v18.17.0a1" scripts/update-submodule.sh
+#
+# After the script finishes, please create a commit "generated python-base update"
+# and send a PR to this repository.
+# TODO(roycaihw): make the script send a PR
 
 set -o errexit
 set -o nounset
@@ -31,58 +36,30 @@ declare -r repo_root
 cd "${repo_root}"
 
 source scripts/util/changelog.sh
+go get k8s.io/release/cmd/release-notes
 
-# TODO(roycaihw): make the script send a PR by default (standalone mode), and
-# have an option to make the script reusable by other release automations.
 TARGET_RELEASE=${TARGET_RELEASE:-"v$(grep "^CLIENT_VERSION = \"" scripts/constants.py | sed "s/CLIENT_VERSION = \"//g" | sed "s/\"//g")"}
-SUBMODULE_SECTION=${SUBMODULE_SECTION:-"\*\*Submodule Change:\*\*"}
 
 # update submodule
 git submodule update --remote
-pulls=$(git diff --submodule | egrep -o "^  > Merge pull request #[0-9]+" | sed 's/  > Merge pull request #//g')
 
 # download release notes
-release_notes=""
-submodule_repo="kubernetes-client/python-base"
-echo "Downloading release notes from submodule repo."
-for pull in ${pulls}; do
-  pull_url="https://github.com/$submodule_repo/pull/${pull}"
-  echo "+++ Downloading python-base patch to /tmp/${pull}.patch"
-  curl -o "/tmp/${pull}.patch" -sSL "${pull_url}.patch"
-  subject=$(grep -m 1 "^Subject" "/tmp/${pull}.patch" | sed -e 's/Subject: \[PATCH//g' | sed 's/.*] //')
-  pull_uid="$submodule_repo#${pull}"
-  release_note="- ${subject} [${pull_uid}](${pull_url})\n"
-  release_notes+=${release_note}
-  # remove the patch file from /tmp
-  rm -f "/tmp/${pull}.patch"
-done
-
-# find the place in the changelog that we want to edit
-line_to_edit="1"
-if util::changelog::has_release $TARGET_RELEASE; then
-  # the target release exists
-  release_first_line=$(util::changelog::find_release_start $TARGET_RELEASE)
-  release_last_line=$(util::changelog::find_release_end $TARGET_RELEASE)
-  if util::changelog::has_section_in_range "$SUBMODULE_SECTION" "$release_first_line" "$release_last_line"; then
-    # prepend to existing section
-    line_to_edit=$(($(util::changelog::find_section_in_range "$SUBMODULE_SECTION" "$release_first_line" "$release_last_line")+1))
-    release_notes=${release_notes::-2}
-  else
-    # add a new section
-    line_to_edit=$(($(util::changelog::find_release_start $TARGET_RELEASE)+4))
-    release_notes="$SUBMODULE_SECTION\n$release_notes"
-  fi
-else
-  # add a new release
-  # TODO(roycaihw): ideally a parent script updates the generated client and
-  # fills in the Kubernetes API Version based on the OpenAPI spec.
-  release_notes="# $TARGET_RELEASE\n\nKubernetes API Version: TBD\n\n$SUBMODULE_SECTION\n$release_notes"
-fi
-
-echo "Writing the following release notes to CHANGELOG line $line_to_edit:"
-echo -e $release_notes
+start_sha=$(git diff | grep "^-Subproject commit " | sed 's/-Subproject commit //g')
+end_sha=$(git diff | grep "^+Subproject commit " | sed 's/+Subproject commit //g')
+output="/tmp/python-base-relnote.md"
+release-notes --dependencies=false --org kubernetes-client --repo python-base --start-sha $start_sha --end-sha $end_sha --output $output
+sed -i 's/(\[\#/(\[kubernetes-client\/python-base\#/g' $output
 
 # update changelog
-sed -i "${line_to_edit}i${release_notes}" CHANGELOG.md
+IFS_backup=$IFS
+IFS=$'\n'
+sections=($(grep "^### " $output))
+IFS=$IFS_backup
+for section in "${sections[@]}"; do
+  # ignore section titles and empty lines; replace newline with liternal "\n"
+  release_notes=$(sed -n "/$section/,/###/{/###/!p}" $output | sed -n "{/^$/!p}" | sed ':a;N;$!ba;s/\n/\\n/g')
+  util::changelog::write_changelog "$TARGET_RELEASE" "$section" "$release_notes"
+done
 
+rm -f $output
 echo "Successfully updated CHANGELOG for submodule."

--- a/scripts/update-submodule.sh
+++ b/scripts/update-submodule.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Update python-base submodule and collect release notes.
+# Usage:
+#   scripts/update-submodule.sh
+#
+# Create a commit "generated python-base update" and send a PR to the main repo.
+# NOTE: not all python-base changes are user-facing, and you may want to remove
+# some of the non-user-facing release notes from CHANGELOG.md.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+declare -r repo_root
+cd "${repo_root}"
+
+source scripts/util/changelog.sh
+
+# TODO(roycaihw): make the script send a PR by default (standalone mode), and
+# have an option to make the script reusable by other release automations.
+TARGET_RELEASE=${TARGET_RELEASE:-"v$(grep "^CLIENT_VERSION = \"" scripts/constants.py | sed "s/CLIENT_VERSION = \"//g" | sed "s/\"//g")"}
+SUBMODULE_SECTION=${SUBMODULE_SECTION:-"\*\*Submodule Change:\*\*"}
+
+# update submodule
+git submodule update --remote
+pulls=$(git diff --submodule | egrep -o "^  > Merge pull request #[0-9]+" | sed 's/  > Merge pull request #//g')
+
+# download release notes
+release_notes=""
+submodule_repo="kubernetes-client/python-base"
+echo "Downloading release notes from submodule repo."
+for pull in ${pulls}; do
+  pull_url="https://github.com/$submodule_repo/pull/${pull}"
+  echo "+++ Downloading python-base patch to /tmp/${pull}.patch"
+  curl -o "/tmp/${pull}.patch" -sSL "${pull_url}.patch"
+  subject=$(grep -m 1 "^Subject" "/tmp/${pull}.patch" | sed -e 's/Subject: \[PATCH//g' | sed 's/.*] //')
+  pull_uid="$submodule_repo#${pull}"
+  release_note="- ${subject} [${pull_uid}](${pull_url})\n"
+  release_notes+=${release_note}
+  # remove the patch file from /tmp
+  rm -f "/tmp/${pull}.patch"
+done
+
+# find the place in the changelog that we want to edit
+line_to_edit="1"
+if util::changelog::has_release $TARGET_RELEASE; then
+  # the target release exists
+  release_first_line=$(util::changelog::find_release_start $TARGET_RELEASE)
+  release_last_line=$(util::changelog::find_release_end $TARGET_RELEASE)
+  if util::changelog::has_section_in_range "$SUBMODULE_SECTION" "$release_first_line" "$release_last_line"; then
+    # prepend to existing section
+    line_to_edit=$(($(util::changelog::find_section_in_range "$SUBMODULE_SECTION" "$release_first_line" "$release_last_line")+1))
+    release_notes=${release_notes::-2}
+  else
+    # add a new section
+    line_to_edit=$(($(util::changelog::find_release_start $TARGET_RELEASE)+4))
+    release_notes="$SUBMODULE_SECTION\n$release_notes"
+  fi
+else
+  # add a new release
+  # TODO(roycaihw): ideally a parent script updates the generated client and
+  # fills in the Kubernetes API Version based on the OpenAPI spec.
+  release_notes="# $TARGET_RELEASE\n\nKubernetes API Version: TBD\n\n$SUBMODULE_SECTION\n$release_notes"
+fi
+
+echo "Writing the following release notes to CHANGELOG line $line_to_edit:"
+echo -e $release_notes
+
+# update changelog
+sed -i "${line_to_edit}i${release_notes}" CHANGELOG.md
+
+echo "Successfully updated CHANGELOG for submodule."

--- a/scripts/util/changelog.sh
+++ b/scripts/util/changelog.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+changelog="$(git rev-parse --show-toplevel)/CHANGELOG.md"
+
+function util::changelog::has_release {
+  local release=$1
+  return $(grep -q "^# $release$" $changelog)
+}
+
+# find_release_start returns the number of the first line of the given release
+function util::changelog::find_release_start {
+  local release=$1
+  echo $(grep -n "^# $release$" $changelog | head -1 | cut -d: -f1)
+}
+
+# find_release_end returns the number of the last line of the given release
+function util::changelog::find_release_end {
+  local release=$1
+
+  local release_start=$(util::changelog::find_release_start $release)
+  local next_release_index=0
+  local releases=($(grep -n "^# " $changelog | cut -d: -f1))
+  for i in "${!releases[@]}"; do
+     if [[ "${releases[$i]}" = "$release_start" ]]; then
+       next_release_index=$((i+1))
+       break
+     fi
+  done
+  # return the line before the next release
+  echo $((${releases[${next_release_index}]}-1))
+}
+
+# has_section returns if the given section exists between start and end
+function util::changelog::has_section_in_range {
+  local section="$1"
+  local start=$2
+  local end=$3
+
+  local lines=($(grep -n "$section" "$changelog" | cut -d: -f1))
+  for i in "${!lines[@]}"; do
+    if [[ ${lines[$i]} -ge $start && ${lines[$i]} -le $end ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# find_section returns the number of the first line of the given section
+function util::changelog::find_section_in_range {
+  local section="$1"
+  local start=$2
+  local end=$3
+
+  local line="0"
+  local lines=($(grep -n "$section" "$changelog" | cut -d: -f1))
+  for i in "${!lines[@]}"; do
+    if [[ ${lines[$i]} -ge $start && ${lines[$i]} -le $end ]]; then
+      line=${lines[$i]}
+      break
+    fi
+  done
+  echo $line
+}


### PR DESCRIPTION
I'm working on adding scripts to automate the release process. This one updates python-base submodule and collects the release notes.

Example output in master branch:
```
$ scripts/update-submodule.sh
Submodule path 'kubernetes/base': checked out 'f38221ce0039b71152963edfc3012576368bdfee'
INFO Using output format: markdown
INFO Gathering release notes
INFO Starting to process commit 1 of 11 (9.09%): f38221ce0039b71152963edfc3012576368bdfee
INFO Starting to process commit 2 of 11 (18.18%): fc5b7302b161697ed6fbdf0c5aa85a119768255a
INFO Starting to process commit 3 of 11 (27.27%): e514f69dff7dc090716a233d16b62f87fcdb5b3d
INFO Starting to process commit 4 of 11 (36.36%): 10ae4760b53a917116ae7525a7bbc94f35632cfb
INFO Starting to process commit 5 of 11 (45.45%): db50d0292eb52ac1162d9eb324662c600c5ea6e3
INFO Starting to process commit 6 of 11 (54.55%): 90399663f378b33227f723d3f0c1677965b6d96b
INFO Starting to process commit 7 of 11 (63.64%): fb425a3bec5e5597ff44e810241699ba57377046
INFO Starting to process commit 8 of 11 (72.73%): ed98daeae96c6dc4f245421497c390c009dcec72
INFO Starting to process commit 9 of 11 (81.82%): 93aa318705b93dbd39a61177bb8d4df9db0dddc4
INFO Starting to process commit 10 of 11 (90.91%): 2ea3efbc628597ed3ed2bf3c16e684727addd75b
INFO Starting to process commit 11 of 11 (100.00%): 060cac10e53169c904e0d50b7448233829019e35
INFO PR #233 seems to contain a release note
INFO PR #234 seems to contain a release note
INFO PR #231 seems to contain a release note
INFO PR #231 seems to contain a release note
INFO PR #234 seems to contain a release note
INFO PR #233 seems to contain a release note
INFO finished gathering release notes in 1.285339237s
INFO Got 3 release notes, performing rendering
INFO Release notes written to file: /tmp/python-base-relnote.md
Writing the following release notes to CHANGELOG line 5:
### Feature
- Load_kube_config_from_dict() support define custom temp files path ([kubernetes-client/python-base#233](https://github.com/kubernetes-client/python-base/pull/233), [@onecer](https://github.com/onecer))

Writing the following release notes to CHANGELOG line 5:
### Bug or Regression
- Fix watch stream non-chunked response handling ([kubernetes-client/python-base#231](https://github.com/kubernetes-client/python-base/pull/231), [@dhague](https://github.com/dhague))
- Fixed a decoding error for BOOTMARK watch events ([kubernetes-client/python-base#234](https://github.com/kubernetes-client/python-base/pull/234), [@yliaog](https://github.com/yliaog))

Successfully updated CHANGELOG for submodule.
```
```
$ git diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 715967add..c18dfd600 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@

 Kubernetes API Version: 1.17.13

+### Bug or Regression
+- Fix watch stream non-chunked response handling ([kubernetes-client/python-base#231](https://github.com/kubernetes-client/python-base/pull/231), [@dhague](https://github.com/dhague))
+- Fixed a decoding error for BOOTMARK watch events ([kubernetes-client/python-base#234](https://github.com/kubernetes-client/python-base/pull/234), [@yliaog](https://github.com/yliaog))
+
+### Feature
+- Load_kube_config_from_dict() support define custom temp files path ([kubernetes-client/python-base#233](https://github.com/kubernetes-client/python-base/pull/233), [@onecer](https://github.com/onecer))
+
 **Important Information:**

 - The Kubernetes Python client versioning scheme has changed. The version numbers used till Kubernetes Python Client v12.y.z lagged behind the actual Kubernetes minor version numbers. From this release, the client is moving a version format `vY.Z.P` where `Y` and `Z` are respectively from the Kubernetes version `v1.Y.Z` and `P` would incremented due to changes on the Python client side itself. Ref: https://github.com/kubernetes-client/python/issues/1244
diff --git a/kubernetes/base b/kubernetes/base
index 060cac10e..f38221ce0 160000
--- a/kubernetes/base
+++ b/kubernetes/base
@@ -1 +1 @@
-Subproject commit 060cac10e53169c904e0d50b7448233829019e35
+Subproject commit f38221ce0039b71152963edfc3012576368bdfee
```

/cc @yliaog