### PR TITLE
simplify & enhance the node_labels.py example

### DIFF
--- a/examples/node_labels.py
+++ b/examples/node_labels.py
@@ -36,10 +36,10 @@ def main():
                 "baz": None}
         }
     }
-   
+
     # Listing the cluster nodes
     node_list = api_instance.list_node()
-    
+
     print("%s\t\t%s" % ("NAME", "LABELS"))
     # Patching the node labels
     for node in node_list.items:

--- a/examples/node_labels.py
+++ b/examples/node_labels.py
@@ -38,9 +38,9 @@ def main():
     }
    
     # Listing the cluster nodes
-    node_list = api_instance.list_node()   
+    node_list = api_instance.list_node()
+    
     print("%s\t\t%s" % ("NAME", "LABELS"))
-
     # Patching the node labels
     for node in node_list.items:
         api_response = api_instance.patch_node(node.metadata.name, body)

--- a/examples/node_labels.py
+++ b/examples/node_labels.py
@@ -23,6 +23,7 @@ This example demonstrates the following:
 
 from kubernetes import client, config
 
+
 def main():
     config.load_kube_config()
 
@@ -37,8 +38,7 @@ def main():
     }
    
     # Listing the cluster nodes
-    node_list = api_instance.list_node()
-    
+    node_list = api_instance.list_node()   
     print("%s\t\t%s" % ("NAME", "LABELS"))
 
     # Patching the node labels

--- a/examples/node_labels.py
+++ b/examples/node_labels.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 """
-Changes the labels of the "minikube" node. Adds the label "foo" with value
-"bar" and will overwrite the "foo" label if it already exists. Removes the
-label "baz".
+This example demonstrates the following:
+    - Get a list of all the cluster nodes
+    - Iterate through each node list item
+        - Add or overwirite label "foo" with the value "bar"
+        - Remove the label "baz"
+    - Return the list of node with updated labels
 """
 
-from pprint import pprint
-
 from kubernetes import client, config
-
 
 def main():
     config.load_kube_config()
@@ -35,10 +35,16 @@ def main():
                 "baz": None}
         }
     }
+   
+    # Creating a list of cluster nodes
+    node_list = api_instance.list_node()
+    
+    print("%s\t\t%s" % ("NAME", "LABELS"))
 
-    api_response = api_instance.patch_node("minikube", body)
-
-    pprint(api_response)
+    # Patching the node labels
+    for node in node_list.items:
+        api_response = api_instance.patch_node(node.metadata.name, body)
+        print("%s\t%s" % (node.metadata.name, node.metadata.labels))
 
 
 if __name__ == '__main__':

--- a/examples/node_labels.py
+++ b/examples/node_labels.py
@@ -36,7 +36,7 @@ def main():
         }
     }
    
-    # Creating a list of cluster nodes
+    # Listing the cluster nodes
     node_list = api_instance.list_node()
     
     print("%s\t\t%s" % ("NAME", "LABELS"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR enhances the existing [node_labels.py](https://github.com/kubernetes-client/python/blob/master/examples/node_labels.py) example, with the following:
- make the script more generic to any kind of Kubernetes cluster, removing the hardcoded node name.
- along with previously demonstrating the use of `patch_node` function, it now also covers the basic concepts like listing cluster nodes using `list_node()` function.
- demonstrate how to get specific node object characteristics field's values, like `<node_item>.metadata.name`, `<node_item>.metadata.labels`.
- print a cleaner output (list of cluster node `name` & the updated `labels`)

```
❯ python3 examples/node_labels.py 
NAME		LABELS
127.0.0.1	{'beta.kubernetes.io/arch': 'amd64', 'beta.kubernetes.io/os': 'linux', 'foo': 'bar', 'kubernetes.io/arch': 'amd64', 'kubernetes.io/hostname': '127.0.0.1', 'kubernetes.io/os': 'linux'}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-client/python/issues/1434

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```