### PR TITLE
Apply-hotfixes: use commits from upstream repo instead of a forked repo

### DIFF
--- a/scripts/apply-hotfixes.sh
+++ b/scripts/apply-hotfixes.sh
@@ -38,7 +38,7 @@ fi
 # UPDATE: The commit being cherry-picked is updated since the the client generated in 1adaaecd0879d7315f48259ad8d6cbd66b835385
 # differs from the initial hotfix
 # Ref: https://github.com/kubernetes-client/python/pull/995/commits/9959273625b999ae9a8f0679c4def2ee7d699ede
-git cherry-pick -n a138dcbb7a9da972402a847ce982b027e0224e60
+git cherry-pick -n 9959273625b999ae9a8f0679c4def2ee7d699ede
 if [ $? -eq 0 ]
 then
     echo Succesfully patched changes for custom client behavior
@@ -51,7 +51,7 @@ fi
 # Patching commits for enabling from kubernetes import apis
 # UPDATE: The commit being cherry-picked is updated to include both the commits as one
 # Ref: https://github.com/kubernetes-client/python/blob/0976d59d6ff206f2f428cabc7a6b7b1144843b2a/kubernetes/client/apis/__init__.py
-git cherry-pick -n 228a29a982aee922831c3af4fef66a7846ce4bb8
+git cherry-pick -n 56ab983036bcb5c78eee91483c1e610da69216d1
 if [ $? -eq 0 ]
 then
     echo Succesfully patched changes for enabling from kubernetes import apis


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
The apply-hotfixes script cherry-picks commits from a [forked repo](https://github.com/palnabarun/python). Before this change, without fetching the forked repo, the script will fail with
```
$ scripts/apply-hotfixes.sh
fatal: bad object a138dcbb7a9da972402a847ce982b027e0224e60
Failed to patch changes for custom client behavior
```
With this change, the requested commits exist in the upstream repo. And since `git fetch upstream` is the [first step](https://github.com/kubernetes-client/python/blob/master/devel/release.md#create-or-update-release-branch) in the release process, the apply-hotfixes script will be able to cherry-pick the commits. 

A side-by-side comparison of the changed commits:
- https://github.com/kubernetes-client/python/commit/a138dcbb7a9da972402a847ce982b027e0224e60 (note the "This commit does not belong to any branch on this repository")
- https://github.com/kubernetes-client/python/commit/9959273625b999ae9a8f0679c4def2ee7d699ede
- https://github.com/kubernetes-client/python/commit/228a29a982aee922831c3af4fef66a7846ce4bb8 (note the "This commit does not belong to any branch on this repository")
- https://github.com/kubernetes-client/python/commit/56ab983036bcb5c78eee91483c1e610da69216d1

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @yliaog @palnabarun 
cc @scottilee 