### PR TITLE
add examples to demonstrate the usage of dynamic client

### DIFF
--- a/examples/deployment_create.py
+++ b/examples/deployment_create.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Creates a deployment using AppsV1Api from file nginx-deployment.yaml.
+"""
+
 from os import path
 
 import yaml

--- a/examples/dynamic-client/cluster_scoped_custom_resource.py
+++ b/examples/dynamic-client/cluster_scoped_custom_resource.py
@@ -1,0 +1,152 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This example demonstrates the following:
+    - Creation of a cluster scoped custom resource definition (CRD) using dynamic-client
+    - Creation of custom resources (CR) using the above created CRD
+    - List, patch(update), delete the custom resources
+    - Delete the custom resource defintion
+"""
+
+from kubernetes import config, dynamic
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
+from kubernetes.client import api_client
+import time
+
+
+def main():
+    # Creating a dynamic client
+    client = dynamic.DynamicClient(
+        api_client.ApiClient(configuration=config.load_kube_config())
+    )
+
+    # fetching the custom resource definition (CRD) api
+    crd_api = client.resources.get(
+        api_version="apiextensions.k8s.io/v1beta1", kind="CustomResourceDefinition"
+    )
+
+    # Creating a Namespaced CRD named "ingressroutes.apps.example.com"
+    name = "ingressroutes.apps.example.com"
+
+    crd_manifest = {
+        "apiVersion": "apiextensions.k8s.io/v1beta1",
+        "kind": "CustomResourceDefinition",
+        "metadata": {
+            "name": name,
+        },
+        "spec": {
+            "group": "apps.example.com",
+            "names": {
+                "kind": "IngressRoute",
+                "listKind": "IngressRouteList",
+                "plural": "ingressroutes",
+                "singular": "ingressroute",
+            },
+            "scope": "Cluster",
+            "version": "v1",
+            "subresources": {"status": {}},
+        },
+    }
+
+    crd_creation_respone = crd_api.create(crd_manifest)
+    print(
+        "\n[INFO] custom resource definition `ingressroutes.apps.example.com` created\n"
+    )
+    print("%s\t\t%s" % ("SCOPE", "NAME"))
+    print(
+        "%s\t\t%s\n"
+        % (crd_creation_respone.spec.scope, crd_creation_respone.metadata.name)
+    )
+
+    # Fetching the "ingressroutes" CRD api
+
+    try:
+        ingressroute_api = client.resources.get(
+            api_version="apps.example.com/v1", kind="IngressRoute"
+        )
+    except ResourceNotFoundError:
+        # Need to wait a sec for the discovery layer to get updated
+        time.sleep(2)
+
+    ingressroute_api = client.resources.get(
+        api_version="apps.example.com/v1", kind="IngressRoute"
+    )
+
+    # Creating a custom resource (CR) `ingress-route-*`, using the above CRD `ingressroutes.apps.example.com`
+
+    ingressroute_manifest_one = {
+        "apiVersion": "apps.example.com/v1",
+        "kind": "IngressRoute",
+        "metadata": {
+            "name": "ingress-route-one",
+        },
+        "spec": {},
+    }
+
+    ingressroute_manifest_second = {
+        "apiVersion": "apps.example.com/v1",
+        "kind": "IngressRoute",
+        "metadata": {
+            "name": "ingress-route-second",
+        },
+        "spec": {},
+    }
+
+    ingressroute_api.create(body=ingressroute_manifest_one)
+    ingressroute_api.create(body=ingressroute_manifest_second)
+    print("\n[INFO] custom resources `ingress-route-*` created\n")
+
+    # Listing the `ingress-route-*` custom resources
+
+    ingress_routes_list = ingressroute_api.get()
+    print("%s\t\t\t\t%s" % ("NAME", "SPEC"))
+    for item in ingress_routes_list.items:
+        print("%s\t\t%s" % (item.metadata.name, item.spec))
+
+    # Patching the ingressroutes custom resources
+
+    ingressroute_manifest_one["spec"]["entrypoints"] = ["websecure"]
+    ingressroute_manifest_second["spec"]["entrypoints"] = ["web"]
+
+    patch_ingressroute_one = ingressroute_api.patch(
+        body=ingressroute_manifest_one, content_type="application/merge-patch+json"
+    )
+    patch_ingressroute_second = ingressroute_api.patch(
+        body=ingressroute_manifest_second, content_type="application/merge-patch+json"
+    )
+
+    print("\n[INFO] custom resources `ingress-route-*` patched\n")
+    patched_ingress_routes_list = ingressroute_api.get()
+    print("%s\t\t\t\t%s" % ("NAME", "SPEC"))
+    for item in patched_ingress_routes_list.items:
+        print("%s\t\t%s" % (item.metadata.name, item.spec))
+
+    # Deleting the ingressroutes custom resources
+
+    delete_ingressroute_one = ingressroute_api.delete(name="ingress-route-one")
+    delete_ingressroute_second = ingressroute_api.delete(name="ingress-route-second")
+
+    print("\n[INFO] custom resources `ingress-route-*` deleted")
+
+    # Deleting the ingressroutes.apps.example.com custom resource definition
+
+    crd_api.delete(name=name)
+    print(
+        "\n[INFO] custom resource definition `ingressroutes.apps.example.com` deleted"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dynamic-client/cluster_scoped_custom_resource.py
+++ b/examples/dynamic-client/cluster_scoped_custom_resource.py
@@ -14,10 +14,10 @@
 
 """
 This example demonstrates the following:
-    - Creation of a cluster scoped custom resource definition (CRD) using dynamic-client
-    - Creation of custom resources (CR) using the above created CRD
-    - List, patch(update), delete the custom resources
-    - Delete the custom resource defintion
+    - Creation of a custom resource definition (CRD) using dynamic-client
+    - Creation of cluster scoped custom resources (CR) using the above created CRD
+    - List, patch (update), delete the custom resources
+    - Delete the custom resource defintion (CRD)
 """
 
 from kubernetes import config, dynamic
@@ -34,40 +34,71 @@ def main():
 
     # fetching the custom resource definition (CRD) api
     crd_api = client.resources.get(
-        api_version="apiextensions.k8s.io/v1beta1", kind="CustomResourceDefinition"
+        api_version="apiextensions.k8s.io/v1", kind="CustomResourceDefinition"
     )
 
     # Creating a Namespaced CRD named "ingressroutes.apps.example.com"
     name = "ingressroutes.apps.example.com"
 
     crd_manifest = {
-        "apiVersion": "apiextensions.k8s.io/v1beta1",
+        "apiVersion": "apiextensions.k8s.io/v1",
         "kind": "CustomResourceDefinition",
         "metadata": {
             "name": name,
         },
         "spec": {
             "group": "apps.example.com",
-            "names": {
-                "kind": "IngressRoute",
-                "listKind": "IngressRouteList",
-                "plural": "ingressroutes",
-                "singular": "ingressroute",
-            },
+            "versions": [
+                {
+                    "name": "v1",
+                    "schema": {
+                        "openAPIV3Schema": {
+                            "properties": {
+                                "spec": {
+                                    "properties": {
+                                        "strategy": {"type": "string"},
+                                        "virtualhost": {
+                                            "properties": {
+                                                "fqdn": {"type": "string"},
+                                                "tls": {
+                                                    "properties": {
+                                                        "secretName": {"type": "string"}
+                                                    },
+                                                    "type": "object",
+                                                },
+                                            },
+                                            "type": "object",
+                                        },
+                                    },
+                                    "type": "object",
+                                }
+                            },
+                            "type": "object",
+                        }
+                    },
+                    "served": True,
+                    "storage": True,
+                }
+            ],
             "scope": "Cluster",
-            "version": "v1",
-            "subresources": {"status": {}},
+            "names": {
+                "plural": "ingressroutes",
+                "listKind": "IngressRouteList",
+                "singular": "ingressroute",
+                "kind": "IngressRoute",
+                "shortNames": ["ir"],
+            },
         },
     }
 
-    crd_creation_respone = crd_api.create(crd_manifest)
+    crd_creation_response = crd_api.create(crd_manifest)
     print(
         "\n[INFO] custom resource definition `ingressroutes.apps.example.com` created\n"
     )
     print("%s\t\t%s" % ("SCOPE", "NAME"))
     print(
         "%s\t\t%s\n"
-        % (crd_creation_respone.spec.scope, crd_creation_respone.metadata.name)
+        % (crd_creation_response.spec.scope, crd_creation_response.metadata.name)
     )
 
     # Fetching the "ingressroutes" CRD api
@@ -86,13 +117,19 @@ def main():
 
     # Creating a custom resource (CR) `ingress-route-*`, using the above CRD `ingressroutes.apps.example.com`
 
-    ingressroute_manifest_one = {
+    ingressroute_manifest_first = {
         "apiVersion": "apps.example.com/v1",
         "kind": "IngressRoute",
         "metadata": {
-            "name": "ingress-route-one",
+            "name": "ingress-route-first",
         },
-        "spec": {},
+        "spec": {
+            "virtualhost": {
+                "fqdn": "www.google.com",
+                "tls": {"secretName": "google-tls"},
+            },
+            "strategy": "RoundRobin",
+        },
     }
 
     ingressroute_manifest_second = {
@@ -101,41 +138,65 @@ def main():
         "metadata": {
             "name": "ingress-route-second",
         },
-        "spec": {},
+        "spec": {
+            "virtualhost": {
+                "fqdn": "www.yahoo.com",
+                "tls": {"secretName": "yahoo-tls"},
+            },
+            "strategy": "RoundRobin",
+        },
     }
 
-    ingressroute_api.create(body=ingressroute_manifest_one)
+    ingressroute_api.create(body=ingressroute_manifest_first)
     ingressroute_api.create(body=ingressroute_manifest_second)
     print("\n[INFO] custom resources `ingress-route-*` created\n")
 
     # Listing the `ingress-route-*` custom resources
 
     ingress_routes_list = ingressroute_api.get()
-    print("%s\t\t\t\t%s" % ("NAME", "SPEC"))
+    print("%s\t\t\t%s\t\t%s\t\t\t\t%s" % ("NAME", "FQDN", "TLS", "STRATEGY"))
     for item in ingress_routes_list.items:
-        print("%s\t\t%s" % (item.metadata.name, item.spec))
+        print(
+            "%s\t%s\t%s\t%s"
+            % (
+                item.metadata.name,
+                item.spec.virtualhost.fqdn,
+                item.spec.virtualhost.tls,
+                item.spec.strategy,
+            )
+        )
 
     # Patching the ingressroutes custom resources
 
-    ingressroute_manifest_one["spec"]["entrypoints"] = ["websecure"]
-    ingressroute_manifest_second["spec"]["entrypoints"] = ["web"]
+    ingressroute_manifest_first["spec"]["strategy"] = "Random"
+    ingressroute_manifest_second["spec"]["strategy"] = "WeightedLeastRequest"
 
-    patch_ingressroute_one = ingressroute_api.patch(
-        body=ingressroute_manifest_one, content_type="application/merge-patch+json"
+    patch_ingressroute_first = ingressroute_api.patch(
+        body=ingressroute_manifest_first, content_type="application/merge-patch+json"
     )
     patch_ingressroute_second = ingressroute_api.patch(
         body=ingressroute_manifest_second, content_type="application/merge-patch+json"
     )
 
-    print("\n[INFO] custom resources `ingress-route-*` patched\n")
+    print(
+        "\n[INFO] custom resources `ingress-route-*` patched to update the strategy\n"
+    )
     patched_ingress_routes_list = ingressroute_api.get()
-    print("%s\t\t\t\t%s" % ("NAME", "SPEC"))
+    print("%s\t\t\t%s\t\t%s\t\t\t\t%s" % ("NAME", "FQDN", "TLS", "STRATEGY"))
     for item in patched_ingress_routes_list.items:
-        print("%s\t\t%s" % (item.metadata.name, item.spec))
+        print(
+            "%s\t%s\t%s\t%s"
+            % (
+                item.metadata.name,
+                item.spec.virtualhost.fqdn,
+                item.spec.virtualhost.tls,
+                item.spec.strategy,
+            )
+        )
 
     # Deleting the ingressroutes custom resources
 
-    delete_ingressroute_one = ingressroute_api.delete(name="ingress-route-one")
+    delete_ingressroute_first = ingressroute_api.delete(name="ingress-route-first")
     delete_ingressroute_second = ingressroute_api.delete(name="ingress-route-second")
 
     print("\n[INFO] custom resources `ingress-route-*` deleted")

--- a/examples/dynamic-client/configmap.py
+++ b/examples/dynamic-client/configmap.py
@@ -1,0 +1,85 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This example demonstrates the following:
+    - Creation of a k8s configmap using dynamic-client
+    - List, patch(update), delete the configmap
+"""
+
+from kubernetes import config, dynamic
+from kubernetes.client import api_client
+
+
+def main():
+    # Creating a dynamic client
+    client = dynamic.DynamicClient(
+        api_client.ApiClient(configuration=config.load_kube_config())
+    )
+
+    # fetching the configmap api
+    api = client.resources.get(api_version="v1", kind="ConfigMap")
+
+    configmap_name = "test-configmap"
+
+    configmap_manifest = {
+        "kind": "ConfigMap",
+        "apiVersion": "v1",
+        "metadata": {
+            "name": configmap_name,
+            "labels": {
+                "foo": "bar",
+            },
+        },
+        "data": {
+            "config.json": '{"command":"/usr/bin/mysqld_safe"}',
+            "frontend.cnf": "[mysqld]\nbind-address = 10.0.0.3\n",
+        },
+    }
+
+    # Creating configmap `test-configmap` in the `default` namespace
+
+    configmap = api.create(body=configmap_manifest, namespace="default")
+
+    print("\n[INFO] configmap `test-configmap` created\n")
+
+    # Listing the configmaps in the `default` namespace
+
+    configmap_list = api.get(
+        name=configmap_name, namespace="default", label_selector="foo=bar"
+    )
+
+    print("NAME:\n%s\n" % (configmap_list.metadata.name))
+    print("DATA:\n%s\n" % (configmap_list.data))
+
+    # Updating the configmap's data, `config.json`
+
+    configmap_manifest["data"]["config.json"] = "{}"
+
+    configmap_patched = api.patch(
+        name=configmap_name, namespace="default", body=configmap_manifest
+    )
+
+    print("\n[INFO] configmap `test-configmap` patched\n")
+    print("NAME:\n%s\n" % (configmap_patched.metadata.name))
+    print("DATA:\n%s\n" % (configmap_patched.data))
+
+    # Deleting configmap `test-configmap` from the `default` namespace
+
+    configmap_deleted = api.delete(name=configmap_name, body={}, namespace="default")
+    print("\n[INFO] configmap `test-configmap` deleted\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dynamic-client/namespaced_custom_resource.py
+++ b/examples/dynamic-client/namespaced_custom_resource.py
@@ -1,0 +1,164 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This example demonstrates the following:
+    - Creation of a namespaced scoped custom resource definition (CRD) using dynamic-client
+    - Creation of custom resources (CR) using the above created CRD
+    - List, patch(update), delete the custom resources
+    - Delete the custom resource defintion
+"""
+
+from kubernetes import config, dynamic
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
+from kubernetes.client import api_client
+import time
+
+
+def main():
+    # Creating a dynamic client
+    client = dynamic.DynamicClient(
+        api_client.ApiClient(configuration=config.load_kube_config())
+    )
+
+    # fetching the custom resource definition (CRD) api
+    crd_api = client.resources.get(
+        api_version="apiextensions.k8s.io/v1beta1", kind="CustomResourceDefinition"
+    )
+
+    # Creating a Namespaced CRD named "ingressroutes.apps.example.com"
+    name = "ingressroutes.apps.example.com"
+
+    crd_manifest = {
+        "apiVersion": "apiextensions.k8s.io/v1beta1",
+        "kind": "CustomResourceDefinition",
+        "metadata": {
+            "name": name,
+            "namespace": "default",
+        },
+        "spec": {
+            "group": "apps.example.com",
+            "names": {
+                "kind": "IngressRoute",
+                "listKind": "IngressRouteList",
+                "plural": "ingressroutes",
+                "singular": "ingressroute",
+            },
+            "scope": "Namespaced",
+            "version": "v1",
+            "subresources": {"status": {}},
+        },
+    }
+
+    crd_creation_respone = crd_api.create(crd_manifest)
+    print(
+        "\n[INFO] custom resource definition `ingressroutes.apps.example.com` created\n"
+    )
+    print("%s\t\t%s" % ("SCOPE", "NAME"))
+    print(
+        "%s\t%s\n"
+        % (crd_creation_respone.spec.scope, crd_creation_respone.metadata.name)
+    )
+
+    # Fetching the "ingressroutes" CRD api
+
+    try:
+        ingressroute_api = client.resources.get(
+            api_version="apps.example.com/v1", kind="IngressRoute"
+        )
+    except ResourceNotFoundError:
+        # Need to wait a sec for the discovery layer to get updated
+        time.sleep(2)
+
+    ingressroute_api = client.resources.get(
+        api_version="apps.example.com/v1", kind="IngressRoute"
+    )
+
+    # Creating a custom resource (CR) `ingress-route-*`, using the above CRD `ingressroutes.apps.example.com`
+
+    ingressroute_manifest_one = {
+        "apiVersion": "apps.example.com/v1",
+        "kind": "IngressRoute",
+        "metadata": {
+            "name": "ingress-route-one",
+            "namespace": "default",
+        },
+        "spec": {},
+    }
+
+    ingressroute_manifest_second = {
+        "apiVersion": "apps.example.com/v1",
+        "kind": "IngressRoute",
+        "metadata": {
+            "name": "ingress-route-second",
+            "namespace": "default",
+        },
+        "spec": {},
+    }
+
+    ingressroute_api.create(body=ingressroute_manifest_one, namespace="default")
+    ingressroute_api.create(body=ingressroute_manifest_second, namespace="default")
+    print("\n[INFO] custom resources `ingress-route-*` created\n")
+
+    # Listing the `ingress-route-*` custom resources
+
+    ingress_routes_list = ingressroute_api.get()
+    print("%s\t\t\t\t%s\t%s" % ("NAME", "NAMESPACE", "SPEC"))
+    for item in ingress_routes_list.items:
+        print(
+            "%s\t\t%s\t\t%s" % (item.metadata.name, item.metadata.namespace, item.spec)
+        )
+
+    # Patching the ingressroutes custom resources
+
+    ingressroute_manifest_one["spec"]["entrypoints"] = ["websecure"]
+    ingressroute_manifest_second["spec"]["entrypoints"] = ["web"]
+
+    patch_ingressroute_one = ingressroute_api.patch(
+        body=ingressroute_manifest_one, content_type="application/merge-patch+json"
+    )
+    patch_ingressroute_second = ingressroute_api.patch(
+        body=ingressroute_manifest_second, content_type="application/merge-patch+json"
+    )
+
+    print("\n[INFO] custom resources `ingress-route-*` patched\n")
+    patched_ingress_routes_list = ingressroute_api.get()
+    print("%s\t\t\t\t%s\t%s" % ("NAME", "NAMESPACE", "SPEC"))
+    for item in patched_ingress_routes_list.items:
+        print(
+            "%s\t\t%s\t\t%s"
+            % (item.metadata.name, item.metadata.namespace, str(item.spec))
+        )
+
+    # Deleting the ingressroutes custom resources
+
+    delete_ingressroute_one = ingressroute_api.delete(
+        name="ingress-route-one", namespace="default"
+    )
+    delete_ingressroute_second = ingressroute_api.delete(
+        name="ingress-route-second", namespace="default"
+    )
+
+    print("\n[INFO] custom resources `ingress-route-*` deleted")
+
+    # Deleting the ingressroutes.apps.example.com custom resource definition
+
+    crd_api.delete(name=name)
+    print(
+        "\n[INFO] custom resource definition `ingressroutes.apps.example.com` deleted"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dynamic-client/node.py
+++ b/examples/dynamic-client/node.py
@@ -1,0 +1,49 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This example demonstrates how to list cluster nodes using dynamic client.
+
+"""
+
+from kubernetes import config, dynamic
+from kubernetes.client import api_client
+
+
+def main():
+    # Creating a dynamic client
+    client = dynamic.DynamicClient(
+        api_client.ApiClient(configuration=config.load_kube_config())
+    )
+
+    # fetching the node api
+    api = client.resources.get(api_version="v1", kind="Node")
+
+    # Listing cluster nodes
+
+    print("%s\t\t%s\t\t%s" % ("NAME", "STATUS", "VERSION"))
+    for item in api.get().items:
+        node = api.get(name=item.metadata.name)
+        print(
+            "%s\t%s\t\t%s\n"
+            % (
+                node.metadata.name,
+                node.status.conditions[3]["type"],
+                node.status.nodeInfo.kubeProxyVersion,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dynamic-client/replication_controller.py
+++ b/examples/dynamic-client/replication_controller.py
@@ -1,0 +1,84 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This example demonstrates the creation, listing & deletion of a namespaced replication controller using dynamic-client.
+"""
+
+from kubernetes import config, dynamic
+from kubernetes.client import api_client
+
+
+def main():
+    # Creating a dynamic client
+    client = dynamic.DynamicClient(
+        api_client.ApiClient(configuration=config.load_kube_config())
+    )
+
+    # fetching the replication controller api
+    api = client.resources.get(api_version="v1", kind="ReplicationController")
+
+    name = "frontend-replication-controller"
+
+    replication_controller_manifest = {
+        "apiVersion": "v1",
+        "kind": "ReplicationController",
+        "metadata": {"labels": {"name": name}, "name": name},
+        "spec": {
+            "replicas": 2,
+            "selector": {"name": name},
+            "template": {
+                "metadata": {"labels": {"name": name}},
+                "spec": {
+                    "containers": [
+                        {
+                            "image": "nginx",
+                            "name": "nginx",
+                            "ports": [{"containerPort": 80, "protocol": "TCP"}],
+                        }
+                    ]
+                },
+            },
+        },
+    }
+
+    # Creating replication-controller `frontend-replication-controller` in the `default` namespace
+    replication_controller = api.create(
+        body=replication_controller_manifest, namespace="default"
+    )
+
+    print("\n[INFO] replication-controller `frontend-replication-controller` created\n")
+
+    # Listing replication-controllers in the `default` namespace
+    replication_controller_created = api.get(name=name, namespace="default")
+
+    print("%s\t%s\t\t\t\t\t%s" % ("NAMESPACE", "NAME", "REPLICAS"))
+    print(
+        "%s\t\t%s\t\t%s\n"
+        % (
+            replication_controller_created.metadata.namespace,
+            replication_controller_created.metadata.name,
+            replication_controller_created.spec.replicas,
+        )
+    )
+
+    # Deleting replication-controller `frontend-service` from the `default` namespace
+
+    replication_controller_deleted = api.delete(name=name, body={}, namespace="default")
+
+    print("[INFO] replication-controller `frontend-replication-controller` deleted\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dynamic-client/service.py
+++ b/examples/dynamic-client/service.py
@@ -1,0 +1,89 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This example demonstrates the following:
+    - Creation of a k8s service using dynamic-client
+    - List, patch(update), delete the service
+"""
+
+from kubernetes import config, dynamic
+from kubernetes.client import api_client
+
+
+def main():
+    # Creating a dynamic client
+    client = dynamic.DynamicClient(
+        api_client.ApiClient(configuration=config.load_kube_config())
+    )
+
+    # fetching the service api
+    api = client.resources.get(api_version="v1", kind="Service")
+
+    name = "frontend-service"
+
+    service_manifest = {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"labels": {"name": name}, "name": name, "resourceversion": "v1"},
+        "spec": {
+            "ports": [
+                {"name": "port", "port": 80, "protocol": "TCP", "targetPort": 80}
+            ],
+            "selector": {"name": name},
+        },
+    }
+
+    # Creating service `frontend-service` in the `default` namespace
+
+    service = api.create(body=service_manifest, namespace="default")
+
+    print("\n[INFO] service `frontend-service` created\n")
+
+    # Listing service `frontend-service` in the `default` namespace
+    service_created = api.get(name=name, namespace="default")
+
+    print("%s\t%s" % ("NAMESPACE", "NAME"))
+    print(
+        "%s\t\t%s\n"
+        % (service_created.metadata.namespace, service_created.metadata.name)
+    )
+
+    # Patching the `spec` section of the `frontend-service`
+
+    service_manifest["spec"]["ports"] = [
+        {"name": "new", "port": 8080, "protocol": "TCP", "targetPort": 8080}
+    ]
+
+    service_patched = api.patch(body=service_manifest, name=name, namespace="default")
+
+    print("\n[INFO] service `frontend-service` patched\n")
+    print("%s\t%s\t\t\t%s" % ("NAMESPACE", "NAME", "PORTS"))
+    print(
+        "%s\t\t%s\t%s\n"
+        % (
+            service_patched.metadata.namespace,
+            service_patched.metadata.name,
+            service_patched.spec.ports,
+        )
+    )
+
+    # Deleting service `frontend-service` from the `default` namespace
+    service_deleted = api.delete(name=name, body={}, namespace="default")
+
+    print("\n[INFO] service `frontend-service` deleted\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/remote_cluster.py
+++ b/examples/remote_cluster.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This example demonstrate communication with a remote Kube cluster from a
-# server outside of the cluster without kube client installed on it.
-# The communication is secured with the use of Bearer token.
+"""
+This example demonstrates the communication between a remote cluster and a
+server outside the cluster without kube client installed on it.
+The communication is secured with the use of Bearer token.
+"""
 
 from kubernetes import client, config
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds example python scripts to demonstrate the usage of [dynamic client](https://github.com/kubernetes-client/python-base/tree/master/dynamic). Below are the files, I've added:

- **cluster_scoped_custom_resource.py**
    `Output:`     
    ![Screenshot from 2021-05-03 13-33-21](https://user-images.githubusercontent.com/30499743/116853769-3a28ae00-ac14-11eb-8526-7d90aaa50d1d.png)


- **namespaced_custom_resource.py**
    `Output:`
     ![Screenshot from 2021-05-03 13-33-15](https://user-images.githubusercontent.com/30499743/116853830-51679b80-ac14-11eb-9e09-89e3aef3d07a.png)

- **configmap.py**
    `Output:`
    ![configmap](https://user-images.githubusercontent.com/30499743/116789770-2bd07a00-aace-11eb-99f0-bd2d2f5202c7.png)

- **node.py**
    `Output:`
    ![node](https://user-images.githubusercontent.com/30499743/116789795-515d8380-aace-11eb-815d-f18ac894d7b7.png)

- **replication_controller.py**
    `Output:`
     ![replication-controller](https://user-images.githubusercontent.com/30499743/116789824-718d4280-aace-11eb-8538-6c021e0c9268.png)

- **service.py**
    `Output:` 
    ![service](https://user-images.githubusercontent.com/30499743/116789832-7fdb5e80-aace-11eb-9728-37571fba49f6.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-client/python/issues/1429

<!--
#### Special notes for your reviewer:

IMO, the `namespaced_custom_resource.py` example helps with this issue, https://github.com/kubernetes-client/python/issues/1388#issuecomment-799574105 as well. 

-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```