### PR TITLE
add example to demonstrate a rolling restart of the deployment

### DIFF
--- a/examples/dynamic-client/deployment_rolling_restart.py
+++ b/examples/dynamic-client/deployment_rolling_restart.py
@@ -1,0 +1,120 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This example demonstrates the following:
+    - Creation of a k8s deployment using dynamic-client
+    - Rolling restart of the deployment (demonstrate patch/update action)
+    - Listing & deletion of the deployment
+"""
+
+
+from kubernetes import config, dynamic
+from kubernetes.client import api_client
+import datetime
+import pytz
+
+def main():
+    # Creating a dynamic client
+    client = dynamic.DynamicClient(
+        api_client.ApiClient(configuration=config.load_kube_config())
+    )
+
+    # fetching the deployment api
+    api = client.resources.get(api_version="apps/v1", kind="Deployment")
+
+    name = "nginx-deployment"
+
+    deployment_manifest = {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {"labels": {"app": "nginx"}, "name": name},
+        "spec": {
+            "replicas": 3,
+            "selector": {"matchLabels": {"app": "nginx"}},
+            "template": {
+                "metadata": {"labels": {"app": "nginx"}},
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "nginx",
+                            "image": "nginx:1.14.2",
+                            "ports": [{"containerPort": 80}],
+                        }
+                    ]
+                },
+            },
+        },
+    }
+
+    # Creating deployment `nginx-deployment` in the `default` namespace
+
+    deployment = api.create(body=deployment_manifest, namespace="default")
+
+    print("\n[INFO] deployment `nginx-deployment` created\n")
+
+    # Listing deployment `nginx-deployment` in the `default` namespace
+
+    deployment_created = api.get(name=name, namespace="default")
+
+    print("%s\t%s\t\t\t%s\t%s" % ("NAMESPACE", "NAME", "REVISION", "RESTARTED-AT"))
+    print(
+        "%s\t\t%s\t%s\t\t%s\n"
+        % (
+            deployment_created.metadata.namespace,
+            deployment_created.metadata.name,
+            deployment_created.metadata.annotations,
+            deployment_created.spec.template.metadata.annotations,
+        )
+    )
+
+    # Patching the `spec.template.metadata` section to add `kubectl.kubernetes.io/restartedAt` annotation
+    # In order to perform a rolling restart on the deployment `nginx-deployment`
+
+    deployment_manifest["spec"]["template"]["metadata"] = {
+        "annotations": {
+            "kubectl.kubernetes.io/restartedAt": datetime.datetime.utcnow()
+            .replace(tzinfo=pytz.UTC)
+            .isoformat()
+        }
+    }
+
+    deployment_patched = api.patch(
+        body=deployment_manifest, name=name, namespace="default"
+    )
+
+    print("\n[INFO] deployment `nginx-deployment` restarted\n")
+    print(
+        "%s\t%s\t\t\t%s\t\t\t\t\t\t%s"
+        % ("NAMESPACE", "NAME", "REVISION", "RESTARTED-AT")
+    )
+    print(
+        "%s\t\t%s\t%s\t\t%s\n"
+        % (
+            deployment_patched.metadata.namespace,
+            deployment_patched.metadata.name,
+            deployment_patched.metadata.annotations,
+            deployment_patched.spec.template.metadata.annotations,
+        )
+    )
+
+    # Deleting deployment `nginx-deployment` from the `default` namespace
+
+    deployment_deleted = api.delete(name=name, body={}, namespace="default")
+
+    print("\n[INFO] deployment `nginx-deployment` deleted\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR add `examples/dynamic-client/deployment_rollout-restart.py` python script, to demonstrate how to perform a rolling restart on a deployment resource.

The output of the script looks like:

![deployment_rolling_restart](https://user-images.githubusercontent.com/30499743/116810944-2cb3eb00-ab64-11eb-9da0-d0a5808473f5.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-client/python/issues/1378

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```