### PR TITLE
update `deployment_crud.py` to include a `restart_deployment` method for typed client

### DIFF
--- a/examples/deployment_crud.py
+++ b/examples/deployment_crud.py
@@ -13,8 +13,15 @@
 # limitations under the License.
 
 """
-Creates, updates, and deletes a deployment using AppsV1Api.
+The example covers the following:
+    - Creation of a deployment using AppsV1Api
+    - update/patch to perform rolling restart on the deployment
+    - deletetion of the deployment
 """
+
+import datetime
+
+import pytz
 
 from kubernetes import client, config
 
@@ -29,56 +36,110 @@ def create_deployment_object():
         ports=[client.V1ContainerPort(container_port=80)],
         resources=client.V1ResourceRequirements(
             requests={"cpu": "100m", "memory": "200Mi"},
-            limits={"cpu": "500m", "memory": "500Mi"}
-        )
+            limits={"cpu": "500m", "memory": "500Mi"},
+        ),
     )
+
     # Create and configurate a spec section
     template = client.V1PodTemplateSpec(
         metadata=client.V1ObjectMeta(labels={"app": "nginx"}),
-        spec=client.V1PodSpec(containers=[container]))
+        spec=client.V1PodSpec(containers=[container]),
+    )
+
     # Create the specification of deployment
     spec = client.V1DeploymentSpec(
-        replicas=3,
-        template=template,
-        selector={'matchLabels': {'app': 'nginx'}})
+        replicas=3, template=template, selector={
+            "matchLabels":
+            {"app": "nginx"}})
+
     # Instantiate the deployment object
     deployment = client.V1Deployment(
         api_version="apps/v1",
         kind="Deployment",
         metadata=client.V1ObjectMeta(name=DEPLOYMENT_NAME),
-        spec=spec)
+        spec=spec,
+    )
 
     return deployment
 
 
-def create_deployment(api_instance, deployment):
+def create_deployment(api, deployment):
     # Create deployement
-    api_response = api_instance.create_namespaced_deployment(
-        body=deployment,
-        namespace="default")
-    print("Deployment created. status='%s'" % str(api_response.status))
+    resp = api.create_namespaced_deployment(
+        body=deployment, namespace="default"
+    )
+
+    print("\n[INFO] deployment `nginx-deployment` created.\n")
+    print("%s\t%s\t\t\t%s\t%s" % ("NAMESPACE", "NAME", "REVISION", "IMAGE"))
+    print(
+        "%s\t\t%s\t%s\t\t%s\n"
+        % (
+            resp.metadata.namespace,
+            resp.metadata.name,
+            resp.metadata.generation,
+            resp.spec.template.spec.containers[0].image,
+        )
+    )
 
 
-def update_deployment(api_instance, deployment):
+def update_deployment(api, deployment):
     # Update container image
     deployment.spec.template.spec.containers[0].image = "nginx:1.16.0"
-    # Update the deployment
-    api_response = api_instance.patch_namespaced_deployment(
-        name=DEPLOYMENT_NAME,
-        namespace="default",
-        body=deployment)
-    print("Deployment updated. status='%s'" % str(api_response.status))
+
+    # patch the deployment
+    resp = api.patch_namespaced_deployment(
+        name=DEPLOYMENT_NAME, namespace="default", body=deployment
+    )
+
+    print("\n[INFO] deployment's container image updated.\n")
+    print("%s\t%s\t\t\t%s\t%s" % ("NAMESPACE", "NAME", "REVISION", "IMAGE"))
+    print(
+        "%s\t\t%s\t%s\t\t%s\n"
+        % (
+            resp.metadata.namespace,
+            resp.metadata.name,
+            resp.metadata.generation,
+            resp.spec.template.spec.containers[0].image,
+        )
+    )
 
 
-def delete_deployment(api_instance):
+def restart_deployment(api, deployment):
+    # update `spec.template.metadata` section
+    # to add `kubectl.kubernetes.io/restartedAt` annotation
+    deployment.spec.template.metadata.annotations = {
+        "kubectl.kubernetes.io/restartedAt": datetime.datetime.utcnow()
+        .replace(tzinfo=pytz.UTC)
+        .isoformat()
+    }
+
+    # patch the deployment
+    resp = api.patch_namespaced_deployment(
+        name=DEPLOYMENT_NAME, namespace="default", body=deployment
+    )
+
+    print("\n[INFO] deployment `nginx-deployment` restarted.\n")
+    print("%s\t\t\t%s\t%s" % ("NAME", "REVISION", "RESTARTED-AT"))
+    print(
+        "%s\t%s\t\t%s\n"
+        % (
+            resp.metadata.name,
+            resp.metadata.generation,
+            resp.spec.template.metadata.annotations,
+        )
+    )
+
+
+def delete_deployment(api):
     # Delete deployment
-    api_response = api_instance.delete_namespaced_deployment(
+    resp = api.delete_namespaced_deployment(
         name=DEPLOYMENT_NAME,
         namespace="default",
         body=client.V1DeleteOptions(
-            propagation_policy='Foreground',
-            grace_period_seconds=5))
-    print("Deployment deleted. status='%s'" % str(api_response.status))
+            propagation_policy="Foreground", grace_period_seconds=5
+        ),
+    )
+    print("\n[INFO] deployment `nginx-deployment` deleted.")
 
 
 def main():
@@ -101,8 +162,10 @@ def main():
 
     update_deployment(apps_v1, deployment)
 
+    restart_deployment(apps_v1, deployment)
+
     delete_deployment(apps_v1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR updates the `examples/deployment_crud.py` python script, to add a `rolling_restart_deployment` method. This new method demonstrates how to perform a rolling restart on a `deployment` resource using the k8s python `typed client`.

The output of the script looks like:
![Screenshot from 2021-05-13 13-54-53](https://user-images.githubusercontent.com/30499743/118099432-d90e9080-b3f2-11eb-92ba-334794d8a93a.png)




#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-client/python/issues/1378

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```