### PR TITLE
Add OS X sed check to update-submodule.sh

### DIFF
--- a/scripts/update-submodule.sh
+++ b/scripts/update-submodule.sh
@@ -31,6 +31,22 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# OS X sed doesn't support "--version". This way we can tell if OS X sed is
+# used.
+if ! sed --version &>/dev/null; then
+  # OS X sed and GNU sed aren't compatible with backup flag "-i". Namely
+  # sed -i ... - does not work on OS X
+  # sed -i'' ... - does not work on certain OS X versions
+  # sed -i '' ... - does not work on GNU
+  echo ">>> OS X sed detected, which may be incompatible with this script. Please install and use GNU sed instead:
+  $ brew install gnu-sed
+  $ brew info gnu-sed
+  # Find the path to the installed gnu-sed and add it to your PATH. The default
+  # is:
+  #   PATH=\"/Users/\$USER/homebrew/opt/gnu-sed/libexec/gnubin:\$PATH\""
+  exit 1
+fi
+
 repo_root="$(git rev-parse --show-toplevel)"
 declare -r repo_root
 cd "${repo_root}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Add the same sed check in [update-client.sh](https://github.com/kubernetes-client/python/blob/master/scripts/update-client.sh#L27-L41) to update-submodule.sh, because update-submodule.sh also contains a `sed -i` command:

```
sed: 1: "/tmp/python-base-relnot ...": extra characters at the end of p command
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @Yashks1994 @yliaog 