### PR TITLE
Refactor OS X sed check into a util

### DIFF
--- a/scripts/update-client.sh
+++ b/scripts/update-client.sh
@@ -24,22 +24,6 @@ set -o pipefail
 # The openapi-generator version used by this client
 export OPENAPI_GENERATOR_COMMIT="v4.3.0"
 
-# OS X sed doesn't support "--version". This way we can tell if OS X sed is
-# used.
-if ! sed --version &>/dev/null; then
-  # OS X sed and GNU sed aren't compatible with backup flag "-i". Namely
-  # sed -i ... - does not work on OS X
-  # sed -i'' ... - does not work on certain OS X versions
-  # sed -i '' ... - does not work on GNU
-  echo ">>> OS X sed detected, which may be incompatible with this script. Please install and use GNU sed instead:
-  $ brew install gnu-sed
-  $ brew info gnu-sed
-  # Find the path to the installed gnu-sed and add it to your PATH. The default
-  # is:
-  #   PATH=\"/Users/\$USER/homebrew/opt/gnu-sed/libexec/gnubin:\$PATH\""
-  exit 1
-fi
-
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 CLIENT_ROOT="${SCRIPT_ROOT}/../kubernetes"
 CLIENT_VERSION=$(python "${SCRIPT_ROOT}/constants.py" CLIENT_VERSION)
@@ -50,11 +34,14 @@ pushd "${SCRIPT_ROOT}" > /dev/null
 SCRIPT_ROOT=`pwd`
 popd > /dev/null
 
+source ${SCRIPT_ROOT}/util/common.sh
+util::common::check_sed
+
 pushd "${CLIENT_ROOT}" > /dev/null
 CLIENT_ROOT=`pwd`
 popd > /dev/null
 
-TEMP_FOLDER=$(mktemp -d) 
+TEMP_FOLDER=$(mktemp -d)
 trap "rm -rf ${TEMP_FOLDER}" EXIT SIGINT
 
 SETTING_FILE="${TEMP_FOLDER}/settings"

--- a/scripts/update-submodule.sh
+++ b/scripts/update-submodule.sh
@@ -31,27 +31,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# OS X sed doesn't support "--version". This way we can tell if OS X sed is
-# used.
-if ! sed --version &>/dev/null; then
-  # OS X sed and GNU sed aren't compatible with backup flag "-i". Namely
-  # sed -i ... - does not work on OS X
-  # sed -i'' ... - does not work on certain OS X versions
-  # sed -i '' ... - does not work on GNU
-  echo ">>> OS X sed detected, which may be incompatible with this script. Please install and use GNU sed instead:
-  $ brew install gnu-sed
-  $ brew info gnu-sed
-  # Find the path to the installed gnu-sed and add it to your PATH. The default
-  # is:
-  #   PATH=\"/Users/\$USER/homebrew/opt/gnu-sed/libexec/gnubin:\$PATH\""
-  exit 1
-fi
 
 repo_root="$(git rev-parse --show-toplevel)"
 declare -r repo_root
 cd "${repo_root}"
 
 source scripts/util/changelog.sh
+source scripts/util/common.sh
+
+util::common::check_sed
 go get k8s.io/release/cmd/release-notes
 
 TARGET_RELEASE=${TARGET_RELEASE:-"v$(grep "^CLIENT_VERSION = \"" scripts/constants.py | sed "s/CLIENT_VERSION = \"//g" | sed "s/\"//g")"}

--- a/scripts/util/common.sh
+++ b/scripts/util/common.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# check_sed returns an error and suggests installing GNU sed, if OS X sed is
+# detected.
+function util::common::check_sed {
+  # OS X sed doesn't support "--version". This way we can tell if OS X sed is
+  # used.
+  if ! sed --version &>/dev/null; then
+    # OS X sed and GNU sed aren't compatible with backup flag "-i". Namely
+    # sed -i ... - does not work on OS X
+    # sed -i'' ... - does not work on certain OS X versions
+    # sed -i '' ... - does not work on GNU
+    echo ">>> OS X sed detected, which may be incompatible with this script. Please install and use GNU sed instead:
+    $ brew install gnu-sed
+    $ brew info gnu-sed
+    # Find the path to the installed gnu-sed and add it to your PATH. The default
+    # is:
+    #   PATH=\"/Users/\$USER/homebrew/opt/gnu-sed/libexec/gnubin:\$PATH\""
+    exit 1
+  fi
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Followup of https://github.com/kubernetes-client/python/pull/1456#issuecomment-836968374. Refactor the sed check into a util.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @yliaog 