### PR TITLE
Fix loss of multi-value headers in request

### DIFF
--- a/kubernetes/client/api_client.py
+++ b/kubernetes/client/api_client.py
@@ -19,6 +19,7 @@ from multiprocessing.pool import ThreadPool
 import os
 import re
 import tempfile
+from urllib3.connection import HTTPHeaderDict
 
 # python 2 and python 3 compatibility library
 import six
@@ -133,7 +134,7 @@ class ApiClient(object):
             header_params['Cookie'] = self.cookie
         if header_params:
             header_params = self.sanitize_for_serialization(header_params)
-            header_params = dict(self.parameters_to_tuples(header_params,
+            header_params = HTTPHeaderDict(self.parameters_to_tuples(header_params,
                                                            collection_formats))
 
         # path parameters


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The api client library currently loses request header values when multiple values are passed.

#### Which issue(s) this PR fixes:

Fixes #1462

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

This adds the capability to pass multiple values in request headers, such as passing multiple values for `Impersonate-Group`

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: