### PR TITLE
Drop python 3.5

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,11 @@ jobs:
 
   - stage: test
     python: 3.9
-    env: TOXENV=update-pycodestyle 
+    env: TOXENV=update-pycodestyle
   - python: 3.9
-    env: TOXENV=coverage,codecov      
+    env: TOXENV=coverage,codecov
   - python: 3.7
     env: TOXENV=docs
-  - python: 3.5
-    env: TOXENV=py35
-  - python: 3.5
-    env: TOXENV=py35-functional
   - python: 3.6
     env: TOXENV=py36
   - python: 3.6
@@ -66,12 +62,9 @@ jobs:
   - stage: test
     python: 3.9
     env: TOXENV=update-pycodestyle
-    arch: ppc64le    
+    arch: ppc64le
   - python: 3.7
     env: TOXENV=docs
-    arch: ppc64le
-  - python: 3.5
-    env: TOXENV=py35
     arch: ppc64le
   - python: 3.6
     env: TOXENV=py36

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-   py3{5,6,7,8,9}
-   py3{5,6,7,8,9}-functional
+   py3{6,7,8,9}
+   py3{6,7,8,9}-functional
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Python 3.5 was EOL'ed on 13 Sep 2020. We shouldn't support Python versions that don't get security updates anymore. ([Ref 1][1], [Ref 2][2])

While going through updating PyYAML due to a CVE fix (#1306), I realized that our dependencies may have dropped support for out-of-support Python minor versions. PyYAML doesn't support Python 3.5 anymore with their latest release.

If we are to fix the CVE, we need to drop Python 3.5. I think we can drop as part of releasing client version v18.y.0b1 as Python doesn't break backward compatibility within minor versions.

[1]: https://devguide.python.org/#status-of-python-branches
[2]: https://endoflife.date/python

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None
