### PR TITLE
tolerate null sources on projected volumes

### DIFF
--- a/kubernetes/client/models/v1_projected_volume_source.py
+++ b/kubernetes/client/models/v1_projected_volume_source.py
@@ -99,9 +99,6 @@ class V1ProjectedVolumeSource(object):
         :param sources: The sources of this V1ProjectedVolumeSource.  # noqa: E501
         :type: list[V1VolumeProjection]
         """
-        if self.local_vars_configuration.client_side_validation and sources is None:  # noqa: E501
-            raise ValueError("Invalid value for `sources`, must not be `None`")  # noqa: E501
-
         self._sources = sources
 
     def to_dict(self):


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Removes false requirement that projected volume sources be a populated list (rather than `null`)

#### Which issue(s) this PR fixes:
Fixes #1494

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE

```release-note
Removed restriction on Projected Volume sources being `null`/`None`
```