### PR TITLE
Require python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
               'kubernetes.dynamic', 'kubernetes.leaderelection'],
     include_package_data=True,
     long_description="Python client for kubernetes http://kubernetes.io/",
+    python_requires='>=3.6',
     classifiers=[
         "Development Status :: %s" % DEVELOPMENT_STATUS,
         "Topic :: Utilities",


### PR DESCRIPTION
#### What type of PR is this?

/kind design
/kind deprecation

#### What this PR does / why we need it:

Limits Python version 3.6 and above according to https://packaging.python.org/guides/dropping-older-python-versions/#specify-the-version-ranges-for-supported-python-distributions

#### Which issue(s) this PR fixes:

Fixes #1502

#### Does this PR introduce a user-facing change?

```release-note
None
```