### PR TITLE
Release automation: tolerate when there is no API change

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -117,12 +117,13 @@ scripts/apply-hotfixes.sh
 git reset HEAD~2
 # custom object API is hosted in gen repo. Commit API change separately for
 # easier review
-if [[ -z "$(git diff kubernetes/client/api/custom_objects_api.py)" ]]; then
+if [[ -n "$(git diff kubernetes/client/api/custom_objects_api.py)" ]]; then
   git add kubernetes/client/api/custom_objects_api.py
   git commit -m "generated client change for custom_objects"
 fi
 git add kubernetes/docs kubernetes/client/api/ kubernetes/client/models/ kubernetes/swagger.json.unprocessed scripts/swagger.json
-git commit -m "generated API change"
+# verify if there are staged changes, then commit
+git diff-index --quiet --cached HEAD || git commit -m "generated API change"
 git add .
 git commit -m "generated client change"
 echo "Release finished successfully."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

The script failed when there is nothing to commit.

I've verified the following command succeeded with the fix in this PR.

```
$ KUBERNETES_BRANCH=release-1.19 CLIENT_VERSION=19.15.0a1 DEVELOPMENT_STATUS="3 - Alpha" scripts/release.sh
```
#### What this PR does / why we need it:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/assign @yliaog 