### PR TITLE
Update Kubernetes API Version if we are generating a snapshot

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -180,6 +180,10 @@ git commit -am "update version constants for $CLIENT_VERSION release"
 # TODO(roycaihw): not all Kubernetes API changes modify the OpenAPI spec.
 # Download the patch and skip if the spec is not modified. Also we want to
 # look at other k/k sections like "deprecation"
+if [[ $CLIENT_VERSION == *"snapshot"* ]]; then
+  # Update "Kubernetes API Version" if we are generating a snapshot
+  util::changelog::update_release_api_version $CLIENT_VERSION $old_client_version $new_k8s_api_version
+fi
 release_notes=$(util::kube_changelog::get_api_changelog "$KUBERNETES_BRANCH" "$old_k8s_api_version")
 if [[ -n "$release_notes" ]]; then
   util::changelog::write_changelog v$CLIENT_VERSION "### API Change" "$release_notes"
@@ -210,4 +214,4 @@ git diff-index --quiet --cached HEAD || git commit -m "generated API change"
 git add .
 git commit -m "generated client change"
 
-echo "Release finished successfully. Please create a PR from branch ${newbranchuniq}."
+echo "Release finished successfully. Please create a PR from branch ${newbranchuniq}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
https://github.com/kubernetes-client/python/pull/1583/commits/a9085a80554477e340507237fca641be001c98bb caused the script to not write "Kubernetes API Version" when generating a snapshot.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```