### PR TITLE
test: WSClient.returncode idempotence

### DIFF
--- a/kubernetes/e2e_test/test_client.py
+++ b/kubernetes/e2e_test/test_client.py
@@ -221,6 +221,7 @@ class TestClient(unittest.TestCase):
             self.assertIsNone(client.returncode)
             client.run_forever(timeout=10)
             self.assertEqual(client.returncode, value)
+            self.assertEqual(client.returncode, value)
 
         resp = api.delete_namespaced_pod(name=name, body={},
                                          namespace='default')

--- a/kubernetes/e2e_test/test_client.py
+++ b/kubernetes/e2e_test/test_client.py
@@ -221,7 +221,7 @@ class TestClient(unittest.TestCase):
             self.assertIsNone(client.returncode)
             client.run_forever(timeout=10)
             self.assertEqual(client.returncode, value)
-            self.assertEqual(client.returncode, value)
+            self.assertEqual(client.returncode, value)  # check idempotence
 
         resp = api.delete_namespaced_pod(name=name, body={},
                                          namespace='default')


### PR DESCRIPTION
This implements a unit test for https://github.com/kubernetes-client/python-base/pull/272

/kind bug

```release-note
Added test to ensure calling WSClient.returncode twice in a row doesn't raise an exception
```