### PR TITLE
Async fix for Dynamic Client

### DIFF
--- a/kubernetes/base/dynamic/client.py
+++ b/kubernetes/base/dynamic/client.py
@@ -267,7 +267,7 @@ class DynamicClient(object):
         # Authentication setting
         auth_settings = ['BearerToken']
 
-        return self.client.call_api(
+        api_response = self.client.call_api(
             path,
             method.upper(),
             path_params,
@@ -281,6 +281,10 @@ class DynamicClient(object):
             _preload_content=False,
             _return_http_data_only=params.get('_return_http_data_only', True)
         )
+        if params.get('async_req'):
+            return api_response.get()
+        else:
+            return api_response
 
     def validate(self, definition, version=None, strict=False):
         """validate checks a kubernetes resource definition


### PR DESCRIPTION
/kind bug

```release-note
Notable feature additions for async creation of Custom resources using dynamic Client
```

What this PR does / why we need it?

async creation of custom resources (CR) using the Custom Resource Definition is failing with the following error

AttributeError: 'ApplyResult' object has no attribute 'data'

Fix for the issue:

For Async call meta_request(func) is failing because response object is different for async vs sync call.The following fix will make sure that response object is same for synchronous and asynchronous calls.

Which issue(s) this PR fixes:
https://github.com/kubernetes-client/python/issues/1626

Special notes for reviewer:

Usually for all async calls we get the response when we make the following call thread.get() but incase of dynamic client async calls I don't see that behavior because of the meta_request(func) is already parsing the response.

Does this PR introduce a user-facing change?
NONE