### PR TITLE
feat: global request timeout setting via config

### DIFF
--- a/kubernetes/client/api_client.py
+++ b/kubernetes/client/api_client.py
@@ -176,6 +176,9 @@ class ApiClient(object):
             # use server/host defined in path or operation instead
             url = _host + resource_path
 
+        if _request_timeout is None:
+            _request_timeout = self.configuration.request_timeout
+
         # perform request and return response
         response_data = self.request(
             method, url, query_params=query_params, headers=header_params,

--- a/kubernetes/client/configuration.py
+++ b/kubernetes/client/configuration.py
@@ -171,6 +171,10 @@ class Configuration(object):
         # Disable client side validation
         self.client_side_validation = True
 
+        self.request_timeout = None
+        """Request timeout
+        """
+
     def __deepcopy__(self, memo):
         cls = self.__class__
         result = cls.__new__(cls)


### PR DESCRIPTION
Thanks for having a look at my PR. :)

#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
It adds the possibility to set request timeouts globally via config, rather than specifying a timeout at every request. This is important because:
* you might forget to set a timeout
* timeouts need to be propagated to every function in which a request is made
* the timeout specification is not important for normal code reading

#### Special notes for your reviewer:
* default behaviour remains unchanged
* this is not a breaking change
* I have not been able to find any tests for timeout settings, but I'd be happy to add some if you point me in the right direction

#### Does this PR introduce a user-facing change?
```release-note
A new field `request_timeout` has been added to the configuration API. Request timeouts can be set globally using this option.
```
