### PR TITLE
fix issue when trying to build ResourceField with argument name 'self'

### DIFF
--- a/kubernetes/base/dynamic/resource.py
+++ b/kubernetes/base/dynamic/resource.py
@@ -298,7 +298,7 @@ class ResourceInstance(object):
 
     def __deserialize(self, field):
         if isinstance(field, dict):
-            return ResourceField(**{
+            return ResourceField(params={
                 k: self.__deserialize(v) for k, v in field.items()
             })
         elif isinstance(field, (list, tuple)):
@@ -359,8 +359,8 @@ class ResourceField(object):
         attributes to be accessed with '.' notation
     """
 
-    def __init__(self, **kwargs):
-        self.__dict__.update(kwargs)
+    def __init__(self, params):
+        self.__dict__.update(**params)
 
     def __repr__(self):
         return pformat(self.__dict__)

--- a/kubernetes/base/dynamic/test_client.py
+++ b/kubernetes/base/dynamic/test_client.py
@@ -558,6 +558,12 @@ class TestDynamicClientSerialization(unittest.TestCase):
         """`ResourceField` is a special type which overwrites `__getattr__` method to return `None`
         when a non-existent attribute was accessed. which means it can pass any `hasattr(...)` tests.
         """
-        res = ResourceField(foo='bar')
+        params = {
+            "foo": "bar",
+            "self": True
+        }
+        res = ResourceField(params=params)
+        self.assertEqual(res["foo"], params["foo"])
+        self.assertEqual(res["self"], params["self"])
         # method will return original object when it doesn't know how to proceed
         self.assertEqual(self.client.serialize_body(res), res)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change

#### What this PR does / why we need it:
ResourceField does not allow ``self`` name argument

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
#1715 
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
