### PR TITLE
fixing listing nodes

### DIFF
--- a/kubernetes/client/models/v1_node_condition.py
+++ b/kubernetes/client/models/v1_node_condition.py
@@ -214,12 +214,13 @@ class V1NodeCondition(object):
         """
         if self.local_vars_configuration.client_side_validation and type is None:  # noqa: E501
             raise ValueError("Invalid value for `type`, must not be `None`")  # noqa: E501
-        allowed_values = ["DiskPressure", "MemoryPressure", "NetworkUnavailable", "PIDPressure", "Ready"]  # noqa: E501
+        allowed_values = ["DiskPressure", "MemoryPressure", "NetworkUnavailable", "PIDPressure", "Ready", "TerminateScheduled", "PreemptScheduled", "FreezeScheduled", "RebootScheduled", "FrequentContainerdRestart", "RedeployScheduled", "ReadonlyFilesystem", "FrequentKubeletRestart", "ContainerRuntimeProblem", "FilesystemCorruptionProblem", "FrequentDockerRestart", "KubeletProblem", "KernelDeadlock","FrequentUnregisterNetDevice"]  # noqa: E501
         if self.local_vars_configuration.client_side_validation and type not in allowed_values:  # noqa: E501
             raise ValueError(
                 "Invalid value for `type` ({0}), must be one of {1}"  # noqa: E501
                 .format(type, allowed_values)
             )
+           
 
         self._type = type
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

``` python
aks_api = client.CoreV1Api()
response = aks_api.list_node()
```
While listing the nodes i'm getting errors, because types were not in the allow list. Not sure what these types are, but adding these allowed me to list the nodes in my cluster. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1735

#### Special notes for your reviewer:

This is my first contribution to an open source project, please help me go through the steps

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
