### PR TITLE
Set cwd to None if empty string for ExecProvider

### DIFF
--- a/kubernetes/base/config/exec_provider.py
+++ b/kubernetes/base/config/exec_provider.py
@@ -53,7 +53,8 @@ class ExecProvider(object):
                 value = item['value']
                 additional_vars[name] = value
             self.env.update(additional_vars)
-        self.cwd = cwd
+        
+        self.cwd = cwd if cwd else None
 
     def run(self, previous_response=None):
         kubernetes_exec_info = {

--- a/kubernetes/base/config/exec_provider.py
+++ b/kubernetes/base/config/exec_provider.py
@@ -54,7 +54,7 @@ class ExecProvider(object):
                 additional_vars[name] = value
             self.env.update(additional_vars)
         
-        self.cwd = cwd if cwd else None
+        self.cwd = cwd or None
 
     def run(self, previous_response=None):
         kubernetes_exec_info = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

If using ExecProvisioner with an inmemory kubeconfig, set cwd to None so that subprocess.Popen works, instead of empty string which breaks. 

#### Which issue(s) this PR fixes:

Fixes #1774 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None