### PR TITLE
FIX:  Update watch resource_version on BOOKMARK events. 

### DIFF
--- a/kubernetes/base/watch/watch.py
+++ b/kubernetes/base/watch/watch.py
@@ -96,11 +96,11 @@ class Watch(object):
     def unmarshal_event(self, data, return_type):
         js = json.loads(data)
         js['raw_object'] = js['object']
-        # BOOKMARK event is treated the same as ERROR for a quick fix of
-        # decoding exception
-        # TODO: make use of the resource_version in BOOKMARK event for more
-        # efficient WATCH
-        if return_type and js['type'] != 'ERROR' and js['type'] != 'BOOKMARK':
+        if return_type and js['type'] != 'ERROR':
+            if js['type'] == 'BOOKMARK':
+                # treat BOOKMARK as a custom object, so that resource_version
+                # is updated
+                return_type = object
             obj = SimpleNamespace(data=json.dumps(js['raw_object']))
             js['object'] = self._api_client.deserialize(obj, return_type)
             if hasattr(js['object'], 'metadata'):


### PR DESCRIPTION
The BOOKMARK feature was not getting used properly. 

it is expected that on the BOOKMARK event, the watch should update it's resource_version to the one in the BOOKMARK event. 

Currently the BOOKMARK event was considered same as ERROR, because of which the watch resource_version was not updated. 

we are now decoding BOOKMARK event as a object/dict, and also updating the watch.resource_version  

/kind bug

Fixes #1729 
Related: 
[#23578](https://github.com/apache/airflow/pull/23578)
[#21087](https://github.com/apache/airflow/issues/21087)


```release-note
NONE
```