### PR TITLE
use unittest.mock instead of mock

### DIFF
--- a/kubernetes/base/config/exec_provider_test.py
+++ b/kubernetes/base/config/exec_provider_test.py
@@ -15,7 +15,7 @@
 import os
 import unittest
 
-import mock
+from unittest import mock
 
 from .config_exception import ConfigException
 from .exec_provider import ExecProvider

--- a/kubernetes/base/config/kube_config_test.py
+++ b/kubernetes/base/config/kube_config_test.py
@@ -22,7 +22,7 @@ import tempfile
 import unittest
 from collections import namedtuple
 
-import mock
+from unittest import mock
 import yaml
 from six import PY3, next
 

--- a/kubernetes/base/watch/watch_test.py
+++ b/kubernetes/base/watch/watch_test.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from mock import Mock, call
+from unittest.mock import Mock, call
 
 from kubernetes import client
 


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:
Use built-in unittest.mock instead of mock.

#### Which issue(s) this PR fixes:
Fixes #1790

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
