### PR TITLE
utils.create_from_yaml_simple_item: use dynamic client to fix crash with custom resources

### DIFF
--- a/kubernetes/e2e_test/test_yaml/crd/controller-crd.yml
+++ b/kubernetes/e2e_test/test_yaml/crd/controller-crd.yml
@@ -1,0 +1,33 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.samplecontroller.x-k8s.io
+spec:
+  group: samplecontroller.x-k8s.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        # schema used for validation
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                deploymentName:
+                  type: string
+                replicas:
+                  type: integer
+                  minimum: 1
+                  maximum: 10
+            status:
+              type: object
+              properties:
+                availableReplicas:
+                  type: integer
+  names:
+    kind: Foo
+    plural: foos
+  scope: Namespaced

--- a/kubernetes/e2e_test/test_yaml/crd/controller-example.yml
+++ b/kubernetes/e2e_test/test_yaml/crd/controller-example.yml
@@ -1,0 +1,7 @@
+apiVersion: samplecontroller.x-k8s.io/v1alpha1
+kind: Foo
+metadata:
+  name: example-foo
+spec:
+  deploymentName: example-foo
+  replicas: 1

--- a/kubernetes/e2e_test/test_yaml/crd/crontab-crd.yml
+++ b/kubernetes/e2e_test/test_yaml/crd/crontab-crd.yml
@@ -1,0 +1,54 @@
+# from https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#specify-multiple-versions
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: crontabs.example.com
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: example.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+  - name: v1beta1
+    # Each version can be enabled/disabled by Served flag.
+    served: true
+    # One and only one version must be marked as the storage version.
+    storage: true
+    # A schema is required
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          host:
+            type: string
+          port:
+            type: string
+  - name: v1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          host:
+            type: string
+          port:
+            type: string
+  # The conversion section is introduced in Kubernetes 1.13+ with a default value of
+  # None conversion (strategy sub-field set to None).
+  conversion:
+    # None conversion assumes the same schema for all versions and only sets the apiVersion
+    # field of custom resources to the proper value
+    strategy: None
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: crontabs
+    # singular name to be used as an alias on the CLI and for display
+    singular: crontab
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CronTab
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - ct

--- a/kubernetes/utils/create_from_yaml.py
+++ b/kubernetes/utils/create_from_yaml.py
@@ -18,7 +18,7 @@ import os
 
 import yaml
 
-from kubernetes import client
+from kubernetes import client, dynamic
 
 UPPER_FOLLOWED_BY_LOWER_RE = re.compile('(.)([A-Z][a-z]+)')
 LOWER_OR_NUM_FOLLOWED_BY_UPPER_RE = re.compile('([a-z0-9])([A-Z])')
@@ -228,41 +228,25 @@ def create_from_dict(k8s_client, data, verbose=False, namespace='default',
 
 def create_from_yaml_single_item(
         k8s_client, yml_object, verbose=False, **kwargs):
-    group, _, version = yml_object["apiVersion"].partition("/")
-    if version == "":
-        version = group
-        group = "core"
-    # Take care for the case e.g. api_type is "apiextensions.k8s.io"
-    # Only replace the last instance
-    group = "".join(group.rsplit(".k8s.io", 1))
-    # convert group name from DNS subdomain format to
-    # python class name convention
-    group = "".join(word.capitalize() for word in group.split('.'))
-    fcn_to_call = "{0}{1}Api".format(group, version.capitalize())
-    k8s_api = getattr(client, fcn_to_call)(k8s_client)
-    # Replace CamelCased action_type into snake_case
-    kind = yml_object["kind"]
-    kind = UPPER_FOLLOWED_BY_LOWER_RE.sub(r'\1_\2', kind)
-    kind = LOWER_OR_NUM_FOLLOWED_BY_UPPER_RE.sub(r'\1_\2', kind).lower()
-    # Expect the user to create namespaced objects more often
-    if hasattr(k8s_api, "create_namespaced_{0}".format(kind)):
-        # Decide which namespace we are going to put the object in,
-        # if any
-        if "namespace" in yml_object["metadata"]:
-            namespace = yml_object["metadata"]["namespace"]
-            kwargs['namespace'] = namespace
-        resp = getattr(k8s_api, "create_namespaced_{0}".format(kind))(
-            body=yml_object, **kwargs)
-    else:
-        kwargs.pop('namespace', None)
-        resp = getattr(k8s_api, "create_{0}".format(kind))(
-            body=yml_object, **kwargs)
+
+    api_version = yml_object.get("apiVersion")
+    kind = yml_object.get("kind")
+    namespace = yml_object.get("metadata", {}).get("namespace")
+
+    dynamic_client = dynamic.DynamicClient(k8s_client)
+    api = dynamic_client.resources.get(api_version=api_version, kind=kind)
+
+    if namespace:
+        kwargs["namespace"] = namespace
+    kwargs["async_req"] = False
+    resp = api.create(body=yml_object, **kwargs)
+
     if verbose:
         msg = "{0} created.".format(kind)
         if hasattr(resp, 'status'):
             msg += " status='{0}'".format(str(resp.status))
         print(msg)
-    return resp
+    return resp.to_dict()
 
 
 class FailToCreateError(Exception):
@@ -278,5 +262,5 @@ class FailToCreateError(Exception):
         msg = ""
         for api_exception in self.api_exceptions:
             msg += "Error from server ({0}): {1}".format(
-                api_exception.reason, api_exception.body)
+                api_exception.reason, api_exception.body.decode())
         return msg


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Fix utils.create_from_yaml_simple_item crash when creating custom resources by using the kubernetes dynamic client.
I also added two tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1792

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
