### PR TITLE
Fix `list_event_for_all_namespaces` when `event_time` is `None`

### DIFF
--- a/kubernetes/client/models/events_v1_event.py
+++ b/kubernetes/client/models/events_v1_event.py
@@ -287,9 +287,6 @@ class EventsV1Event(object):
         :param event_time: The event_time of this EventsV1Event.  # noqa: E501
         :type: datetime
         """
-        if self.local_vars_configuration.client_side_validation and event_time is None:  # noqa: E501
-            raise ValueError("Invalid value for `event_time`, must not be `None`")  # noqa: E501
-
         self._event_time = event_time
 
     @property

--- a/kubernetes/client/models/v1beta1_event.py
+++ b/kubernetes/client/models/v1beta1_event.py
@@ -287,9 +287,6 @@ class V1beta1Event(object):
         :param event_time: The event_time of this V1beta1Event.  # noqa: E501
         :type: datetime
         """
-        if self.local_vars_configuration.client_side_validation and event_time is None:  # noqa: E501
-            raise ValueError("Invalid value for `event_time`, must not be `None`")  # noqa: E501
-
         self._event_time = event_time
 
     @property


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

As discussed in #1826 the following error appears when when using `list_event_for_all_namespaces`:

```py
from kubernetes import config, client

config.load_kube_config()
api = client.EventsV1beta1Api()
print(api.list_event_for_all_namespaces())
```

The error:

```sh
...
ValueError: Invalid value for `event_time`, must not be `None`
```

This could easily be validated by targeting a minikube cluster using `minikube start`, which is also on what I tested the changes this PR makes. The API supports using None for the `event_time`. This PR removes the check to do so. I tested this out locally for minikube clusters and the tests pass as well.

#### Which issue(s) this PR fixes:

Fixes #1826

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
