### PR TITLE
Fix DynamicClient.server_side_apply

### DIFF
--- a/kubernetes/base/dynamic/test_client.py
+++ b/kubernetes/base/dynamic/test_client.py
@@ -15,7 +15,6 @@
 import time
 import unittest
 import uuid
-import json
 
 from kubernetes.e2e_test import base
 from kubernetes.client import api_client
@@ -527,9 +526,8 @@ class TestDynamicClient(unittest.TestCase):
                             'ports': [{'containerPort': 80,
                                             'protocol': 'TCP'}]}]}}
 
-        body = json.dumps(pod_manifest).encode()
         resp = api.server_side_apply(
-            name=name, namespace='default', body=body,
+            namespace='default', body=pod_manifest,
             field_manager='kubernetes-unittests', dry_run="All")
         self.assertEqual('kubernetes-unittests', resp.metadata.managedFields[0].manager)
 

--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -157,7 +157,8 @@ class RESTClientObject(object):
             if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
                 if query_params:
                     url += '?' + urlencode(query_params)
-                if re.search('json', headers['Content-Type'], re.IGNORECASE):
+                if (re.search('json', headers['Content-Type'], re.IGNORECASE) or
+                        headers['Content-Type'] == 'application/apply-patch+yaml'):
                     if headers['Content-Type'] == 'application/json-patch+json':
                         if not isinstance(body, list):
                             headers['Content-Type'] = \

--- a/scripts/rest_client_patch.diff
+++ b/scripts/rest_client_patch.diff
@@ -5,7 +5,9 @@ index 65fbe95..e174317 100644
 @@ -152,6 +152,10 @@ class RESTClientObject(object):
                  if query_params:
                      url += '?' + urlencode(query_params)
-                 if re.search('json', headers['Content-Type'], re.IGNORECASE):
+-                if re.search('json', headers['Content-Type'], re.IGNORECASE):
++                if (re.search('json', headers['Content-Type'], re.IGNORECASE) or
++                        headers['Content-Type'] == 'application/apply-patch+yaml'):
 +                    if headers['Content-Type'] == 'application/json-patch+json':
 +                        if not isinstance(body, list):
 +                            headers['Content-Type'] = \


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`DynamicClient.server_side_apply` is obviously designed to accept a `dict` or a `ResourceInstance` as `body` like other methods.
(This is why the `name` and `namespace` parameters are treated as optional.)
However, if a `dict` or a `ResourceInstance` is passed actually, an error occurs because `RESTClientObject.rest` cannot interpret the `Content-Type` `application/apply-patch+yaml`.

So, modify `RESTClientObject.rest` to treat `application/apply-patch+yaml` as other json-based `Content-Type`s.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Yes.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
You can no longer specify an argument of type str or bytes for the body parameter of DynamicClient.server_side_apply.
Pass an argument of type dict or ResourceInstance instead.
Accordingly, the name and namespace parameters can now be omitted if the body argument contains appropriate metadata.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
