### PR TITLE
Deploy docs as wiki

### DIFF
--- a/.github/workflows/deploy-wiki.yaml
+++ b/.github/workflows/deploy-wiki.yaml
@@ -1,0 +1,37 @@
+name: Deploy Wiki
+
+on:
+  push:
+    paths:
+      - 'kubernetes/docs/**'
+    branches:
+      - master
+
+jobs:
+  deploy-wiki:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Install rsync
+      run: |
+        sudo apt install rsync grsync
+    - name: Clone Wiki
+      run: |
+        git config --global --add safe.directory "/github/workspace"
+        git config --global --add safe.directory "/github/workspace/wiki"
+        git clone https://github.com/kubernetes-client/python.wiki.git wiki
+        message=$(git log -1 --format=%B)
+    - name: Copy to wiki repository
+      run: |
+        rsync -av --delete kubernetes/docs/ wiki/ --exclude .git
+    - name: Push wiki
+      run: |
+        cd wiki
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add .
+        git commit -m "$message"
+        git push
+        


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind feature

#### What this PR does / why we need it:

This PR introduces a new GitHub action that pushes `kubernetes/docs/` to GitHub wiki. The current markdown files are often quite big and end up in errors when trying to open them on GitHub.

From https://github.com/kubernetes-client/python/issues/1557#issuecomment-955112451

> The Wiki page sometimes worked for me and sometimes didn't. I really like it though. Regardless of the rendering issue, I think it helps if we have a centralized place for installation, examples, API doc, contribution, etc.

More information on why this is needed can be found at #1557.

#### Which issue(s) this PR fixes:

Fixes #1557

#### Special notes for your reviewer:

This PR first requires the use of Wikis to be enabled on this repository as well as create a home page for the wiki to allow pulling the wiki in the first place.

/cc @roycaihw 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
