### PR TITLE
fix: account for async_req=True in create_from_yaml_single_item

### DIFF
--- a/kubernetes/e2e_test/test_utils.py
+++ b/kubernetes/e2e_test/test_utils.py
@@ -460,3 +460,24 @@ class TestUtils(unittest.TestCase):
             name="mock-pod-1", namespace=self.test_namespace, body={})
         app_api.delete_namespaced_deployment(
             name="mock", namespace=self.test_namespace, body={})
+
+    # Error test case scenarios
+
+    # Issue #1864.
+    def test_error_creating_resource_in_non_existent_namespace(self):
+        """
+        Should return a valid error when trying to create a resource
+        in non-existent namespace.
+        """
+        resource = self.path_prefix + "job-non-existent-namespace.yaml"
+        k8s_client = client.ApiClient(configuration=self.config)
+        with self.assertRaises(utils.FailToCreateError):
+            utils.create_from_yaml(k8s_client, resource, async_req=False)
+
+        with self.assertRaises(utils.FailToCreateError):
+            utils.create_from_yaml(k8s_client, resource, async_req=True)
+
+        core_api = client.CoreV1Api(k8s_client)
+        nmsps = core_api.list_namespace()
+        nmsps = [nmsp.metadata.name for nmsp in nmsps.items]
+        self.assertNotIn("non-existent-namespace", nmsps)

--- a/kubernetes/e2e_test/test_yaml/job-non-existent-namespace.yaml
+++ b/kubernetes/e2e_test/test_yaml/job-non-existent-namespace.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: non-existent-namespace
+  name: test-job
+spec:
+  template:
+    metadata:
+      labels:
+        app: test-job
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: test-job
+          image: some-image:latest
+          imagePullPolicy: IfNotPresent

--- a/kubernetes/utils/create_from_yaml.py
+++ b/kubernetes/utils/create_from_yaml.py
@@ -257,6 +257,10 @@ def create_from_yaml_single_item(
         kwargs.pop('namespace', None)
         resp = getattr(k8s_api, "create_{0}".format(kind))(
             body=yml_object, **kwargs)
+
+    if kwargs.get('async_req'):
+        resp = resp.get()
+
     if verbose:
         msg = "{0} created.".format(kind)
         if hasattr(resp, 'status'):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In cases when `utils.create_from_yaml_single_item()` is called with `async_req = True` we need to retrieve the actual result of the call from the queue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1864

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
