### PR TITLE
Add request info into ApiException

### DIFF
--- a/kubernetes/client/exceptions.py
+++ b/kubernetes/client/exceptions.py
@@ -83,7 +83,8 @@ class ApiKeyError(OpenApiException, KeyError):
 
 class ApiException(OpenApiException):
 
-    def __init__(self, status=None, reason=None, http_resp=None):
+    def __init__(self, status=None, reason=None, http_resp=None,
+                 request_method=None, request_url=None, request_headers=None):
         if http_resp:
             self.status = http_resp.status
             self.reason = http_resp.reason
@@ -94,6 +95,9 @@ class ApiException(OpenApiException):
             self.reason = reason
             self.body = None
             self.headers = None
+        self.request_method = request_method
+        self.request_url = request_url
+        self.request_headers = request_headers
 
     def __str__(self):
         """Custom error messages for exception"""
@@ -105,6 +109,15 @@ class ApiException(OpenApiException):
 
         if self.body:
             error_message += "HTTP response body: {0}\n".format(self.body)
+
+        if self.request_method:
+            error_message += "HTTP request method: {0}\n".format(self.request_method)
+
+        if self.request_url:
+            error_message += "HTTP request url: {0}\n".format(self.request_url)
+
+        if self.request_headers:
+            error_message += "HTTP request headers: {0}\n".format(self.request_headers)
 
         return error_message
 

--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -232,7 +232,10 @@ class RESTClientObject(object):
             logger.debug("response body: %s", r.data)
 
         if not 200 <= r.status <= 299:
-            raise ApiException(http_resp=r)
+            raise ApiException(http_resp=r,
+                               request_url=url,
+                               request_headers=headers,
+                               request_method=method)
 
         return r
 


### PR DESCRIPTION
Fixes #1872

When I query nonexistent resource type, I got ApiException:
```
kubernetes.client.exceptions.ApiException: (404)
Reason: Not Found
HTTP response headers: HTTPHeaderDict({'Audit-Id': '9954faf3-7258-4619-b6b4-c3ac0b55a340', 'Cache-Control': 'no-cache, private', 'Content-Type': 'text/plain; charset=utf-8', 'X-Content-Type-Options': 'nosniff', 'X-Kubernetes-Pf-Flowschema-Uid': 'cee19ddf-4747-45cb-93a7-e774fe2a061e', 'X-Kubernetes-Pf-Prioritylevel-Uid': '1d97a02a-9039-4fde-bf2e-1e9779e51408', 'Date': 'Thu, 04 Aug 2022 10:14:55 GMT', 'Content-Length': '19'})
HTTP response body: b'404 page not found\n'
```

This is not helpful enough, because it not possible to figure out what actually was requested.
It would be very helpful if there was request info included as well.

ApiException after merging this request will be looking like this:

```
kubernetes.client.exceptions.ApiException: (404)
Reason: Not Found
HTTP response headers: HTTPHeaderDict(......)
HTTP response body: b'404 page not found\n'
HTTP request method: GET
HTTP request url: https://10.7.1.3:8443/apis/example.com/v1alpha1/namespaces/default/invalid
HTTP request headers: {'Accept': 'application/json', ......}
```

