### PR TITLE
Add to_dict method to ResourceField

### DIFF
--- a/kubernetes/base/dynamic/resource.py
+++ b/kubernetes/base/dynamic/resource.py
@@ -389,3 +389,15 @@ class ResourceField(object):
     def __iter__(self):
         for k, v in self.__dict__.items():
             yield (k, v)
+
+    def to_dict(self):
+        return self.__serialize(self)
+
+    def __serialize(self, field):
+        if isinstance(field, ResourceField):
+            return {
+                k: self.__serialize(v) for k, v in field.__dict__.items()
+            }
+        if isinstance(field, (list, tuple)):
+            return [self.__serialize(item) for item in field]
+        return field

--- a/kubernetes/base/dynamic/test_client.py
+++ b/kubernetes/base/dynamic/test_client.py
@@ -563,5 +563,4 @@ class TestDynamicClientSerialization(unittest.TestCase):
         res = ResourceField(params=params)
         self.assertEqual(res["foo"], params["foo"])
         self.assertEqual(res["self"], params["self"])
-        # method will return original object when it doesn't know how to proceed
-        self.assertEqual(self.client.serialize_body(res), res)
+        self.assertEqual(self.client.serialize_body(res), params)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This allows to recursively convert ResourceFields to dicts.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add to_dict method to ResourceField
```
