### PR TITLE
Adds support for custom Server Name Indication (SNI)

### DIFF
--- a/kubernetes/base/config/kube_config.py
+++ b/kubernetes/base/config/kube_config.py
@@ -567,6 +567,8 @@ class KubeConfigLoader(object):
                         temp_file_path=self._temp_file_path).as_file()
         if 'insecure-skip-tls-verify' in self._cluster:
             self.verify_ssl = not self._cluster['insecure-skip-tls-verify']
+        if 'tls-server-name' in self._cluster:
+            self.tls_server_name = self._cluster['tls-server-name']
 
     def _set_config(self, client_configuration):
         if 'token' in self.__dict__:
@@ -578,7 +580,7 @@ class KubeConfigLoader(object):
                 self._set_config(client_configuration)
             client_configuration.refresh_api_key_hook = _refresh_api_key
         # copy these keys directly from self to configuration object
-        keys = ['host', 'ssl_ca_cert', 'cert_file', 'key_file', 'verify_ssl']
+        keys = ['host', 'ssl_ca_cert', 'cert_file', 'key_file', 'verify_ssl','tls_server_name']
         for key in keys:
             if key in self.__dict__:
                 setattr(client_configuration, key, getattr(self, key))

--- a/kubernetes/base/stream/ws_client.py
+++ b/kubernetes/base/stream/ws_client.py
@@ -475,6 +475,8 @@ def create_websocket(configuration, url, headers=None):
         ssl_opts['certfile'] = configuration.cert_file
     if configuration.key_file:
         ssl_opts['keyfile'] = configuration.key_file
+    if configuration.tls_server_name:
+        ssl_opts['server_hostname'] = configuration.tls_server_name
 
     websocket = WebSocket(sslopt=ssl_opts, skip_utf8_validation=False)
     connect_opt = {

--- a/kubernetes/client/configuration.py
+++ b/kubernetes/client/configuration.py
@@ -144,6 +144,10 @@ class Configuration(object):
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by Kubernetes API.
+        """
 
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved

--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -77,6 +77,9 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
         if maxsize is None:
             if configuration.connection_pool_maxsize is not None:
                 maxsize = configuration.connection_pool_maxsize

--- a/scripts/rest_sni_patch.diff
+++ b/scripts/rest_sni_patch.diff
@@ -1,0 +1,29 @@
+diff --git a/kubernetes/client/configuration.py b/kubernetes/client/configuration.py
+index 2b9dd96a50..ac5a18bf8a 100644
+--- a/kubernetes/client/configuration.py
++++ b/kubernetes/client/configuration.py
+@@ -144,6 +144,10 @@ def __init__(self, host="http://localhost",
+         self.assert_hostname = None
+         """Set this to True/False to enable/disable SSL hostname verification.
+         """
++        self.tls_server_name = None
++        """SSL/TLS Server Name Indication (SNI)
++           Set this to the SNI value expected by the server.
++        """
+
+         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
+         """urllib3 connection pool's maximum number of connections saved
+diff --git a/kubernetes/client/rest.py b/kubernetes/client/rest.py
+index 48cd2b7752..4f04251bbf 100644
+--- a/kubernetes/client/rest.py
++++ b/kubernetes/client/rest.py
+@@ -77,6 +77,9 @@ def __init__(self, configuration, pools_size=4, maxsize=None):
+         if configuration.retries is not None:
+             addition_pool_args['retries'] = configuration.retries
+
++        if configuration.tls_server_name:
++            addition_pool_args['server_hostname'] = configuration.tls_server_name
++
+         if maxsize is None:
+             if configuration.connection_pool_maxsize is not None:
+                 maxsize = configuration.connection_pool_maxsize

--- a/scripts/update-client.sh
+++ b/scripts/update-client.sh
@@ -59,7 +59,7 @@ else
 fi
 
 echo ">>> Running python generator from the gen repo"
-"${GEN_ROOT}/openapi/python.sh" "${CLIENT_ROOT}" "${SETTING_FILE}" 
+"${GEN_ROOT}/openapi/python.sh" "${CLIENT_ROOT}" "${SETTING_FILE}"
 mv "${CLIENT_ROOT}/swagger.json" "${SCRIPT_ROOT}/swagger.json"
 
 echo ">>> updating version information..."
@@ -73,6 +73,11 @@ sed -i'' "s,^DEVELOPMENT_STATUS = .*,DEVELOPMENT_STATUS = \\\"${DEVELOPMENT_STAT
 # second, this should be ported to swagger-codegen
 echo ">>> patching client..."
 git apply "${SCRIPT_ROOT}/rest_client_patch.diff"
+# The fix this patch is trying to make is already in the upstream swagger-codegen
+# repo but it's not in the version we're using. We can remove this patch
+# once we upgrade to a version of swagger-codegen that includes it (version>= 6.6.0).
+# See https://github.com/OpenAPITools/openapi-generator/pull/15283
+git apply "${SCRIPT_ROOT}/rest_sni_patch.diff"
 
 echo ">>> generating docs..."
 pushd "${DOC_ROOT}" > /dev/null


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR adds support for custom SNI values. If `tls-server-name` is set in kubeconfig, the client did not use it resulting in SSL/TLS errors if the property is required to connect to the server.

#### Which issue(s) this PR fixes:
Fixes #1889

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed `tls-server-name` (SNI)  property usage when explicitly set in kubeconfig.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

