### PR TITLE
Fixed double module imports

### DIFF
--- a/kubernetes/__init__.py
+++ b/kubernetes/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors.
+# Copyright 2022 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@ __project__ = 'kubernetes'
 # The version is auto-updated. Please do not edit.
 __version__ = "25.0.0-snapshot"
 
-import kubernetes.client
-import kubernetes.config
-import kubernetes.dynamic
-import kubernetes.watch
-import kubernetes.stream
-import kubernetes.utils
-import kubernetes.leaderelection
+from . import client
+from . import config
+from . import dynamic
+from . import watch
+from . import stream
+from . import utils
+from . import leaderelection


### PR DESCRIPTION
In Python, when you write `import foo.bar.baz` this means that the modules would be imported and the name `foo` will be bound locally and becomes available in the module. https://docs.python.org/3/reference/simple_stmts.html#import

So, doing `import kubernetes.client` leads to name `kubernetes` (not `client`) being added to the `kubernetes` module leading to a weird infinite deep nesting. See:
```
>>> import kubernetes
>>> kubernetes
<module 'kubernetes' from 'C:\\Users\\Ark\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\kubernetes\\__init__.py'>
>>> kubernetes.kubernetes.kubernetes
<module 'kubernetes' from 'C:\\Users\\Ark\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\kubernetes\\__init__.py'>
```

Another issue is that while `import kubernetes.client` in `kubernetes.__init__.py` technically makes `kubernetes.client` available in user code that does `import kubernetes`, this a availability is a somewhat brittle side-effect of importing. Some linters and code tools do not see this effect and do not understand that the `kubernetes.client` attribute would be set at runtime. Using explicit import (`from kubernetes import client`) in `kubernetes.__init__.py` solves this issue.

We can solve this issues by using the `import ... from ...` syntax: Replace `import kubernetes.client` with `from kubernetes import client`.

I see that most modules already use relative imports, so I'm using relative imports here as well: `from . import client`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
