### PR TITLE
Only use `usedforsecurity` if supported

### DIFF
--- a/kubernetes/base/dynamic/discovery.py
+++ b/kubernetes/base/dynamic/discovery.py
@@ -45,7 +45,11 @@ class Discoverer(object):
         default_cache_id = self.client.configuration.host
         if six.PY3:
             default_cache_id = default_cache_id.encode('utf-8')
-        default_cachefile_name = 'osrcp-{0}.json'.format(hashlib.md5(default_cache_id, usedforsecurity=False).hexdigest())
+        try:
+            default_cachefile_name = 'osrcp-{0}.json'.format(hashlib.md5(default_cache_id, usedforsecurity=False).hexdigest())
+        except TypeError:
+            # usedforsecurity is only supported in 3.9+
+            default_cachefile_name = 'osrcp-{0}.json'.format(hashlib.md5(default_cache_id).hexdigest())
         self.__cache_file = cache_file or os.path.join(tempfile.gettempdir(), default_cachefile_name)
         self.__init_cache()
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`usedforsecurity` was only added in Python 3.9, will fall back to the old behavior if `usedforsecurity` is not available.

#### Which issue(s) this PR fixes:
Fixes #1944

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
