### PR TITLE
Fix load_kube_config unexpected `kube_config_path` keyword argument

### DIFF
--- a/kubernetes/base/config/__init__.py
+++ b/kubernetes/base/config/__init__.py
@@ -34,6 +34,7 @@ def load_config(**kwargs):
     load_incluster_config functions.
     """
     if "kube_config_path" in kwargs.keys() or exists(expanduser(KUBE_CONFIG_DEFAULT_LOCATION)):
+        kwargs["config_file"] = kwargs.pop("kube_config_path", None)
         load_kube_config(**kwargs)
     else:
         print(

--- a/kubernetes/base/config/__init__.py
+++ b/kubernetes/base/config/__init__.py
@@ -33,7 +33,9 @@ def load_config(**kwargs):
     can be passed to either load_kube_config or
     load_incluster_config functions.
     """
-    if "kube_config_path" in kwargs.keys():
+    if "config_file" in kwargs.keys():
+        load_kube_config(**kwargs)
+    elif "kube_config_path" in kwargs.keys():
         kwargs["config_file"] = kwargs.pop("kube_config_path", None)
         load_kube_config(**kwargs)
     elif exists(expanduser(KUBE_CONFIG_DEFAULT_LOCATION)):

--- a/kubernetes/base/config/__init__.py
+++ b/kubernetes/base/config/__init__.py
@@ -34,9 +34,7 @@ def load_config(**kwargs):
     load_incluster_config functions.
     """
     if "kube_config_path" in kwargs.keys():
-        kube_config_path = kwargs.pop("kube_config_path", None)
-        if "config_file" not in kwargs.keys():
-            kwargs["config_file"] = kube_config_path
+        kwargs["config_file"] = kwargs.pop("kube_config_path", None)
         load_kube_config(**kwargs)
     elif exists(expanduser(KUBE_CONFIG_DEFAULT_LOCATION)):
         load_kube_config(**kwargs)

--- a/kubernetes/base/config/__init__.py
+++ b/kubernetes/base/config/__init__.py
@@ -33,8 +33,12 @@ def load_config(**kwargs):
     can be passed to either load_kube_config or
     load_incluster_config functions.
     """
-    if "kube_config_path" in kwargs.keys() or exists(expanduser(KUBE_CONFIG_DEFAULT_LOCATION)):
-        kwargs["config_file"] = kwargs.pop("kube_config_path", None)
+    if "kube_config_path" in kwargs.keys():
+        kube_config_path = kwargs.pop("kube_config_path", None)
+        if "config_file" not in kwargs.keys():
+            kwargs["config_file"] = kube_config_path
+        load_kube_config(**kwargs)
+    elif exists(expanduser(KUBE_CONFIG_DEFAULT_LOCATION)):
         load_kube_config(**kwargs)
     else:
         print(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Rename `kube_config_path` to the correct `config_file`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1893 

#### Special notes for your reviewer:
Compatible `kube_config_path` argument, no break change.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
