### PR TITLE
kube-config: add custom client configuration injection

### DIFF
--- a/kubernetes/base/config/kube_config.py
+++ b/kubernetes/base/config/kube_config.py
@@ -860,32 +860,36 @@ def load_kube_config_from_dict(config_dict, context=None,
 def new_client_from_config(
         config_file=None,
         context=None,
-        persist_config=True):
+        persist_config=True,
+        client_configuration=None):
     """
     Loads configuration the same as load_kube_config but returns an ApiClient
     to be used with any API object. This will allow the caller to concurrently
     talk with multiple clusters.
     """
-    client_config = type.__call__(Configuration)
+    if client_configuration is None:
+        client_configuration = type.__call__(Configuration)
     load_kube_config(config_file=config_file, context=context,
-                     client_configuration=client_config,
+                     client_configuration=client_configuration,
                      persist_config=persist_config)
-    return ApiClient(configuration=client_config)
+    return ApiClient(configuration=client_configuration)
 
 
 def new_client_from_config_dict(
         config_dict=None,
         context=None,
         persist_config=True,
-        temp_file_path=None):
+        temp_file_path=None,
+        client_configuration=None):
     """
     Loads configuration the same as load_kube_config_from_dict but returns an ApiClient
     to be used with any API object. This will allow the caller to concurrently
     talk with multiple clusters.
     """
-    client_config = type.__call__(Configuration)
+    if client_configuration is None:
+        client_configuration = type.__call__(Configuration)
     load_kube_config_from_dict(config_dict=config_dict, context=context,
-                               client_configuration=client_config,
+                               client_configuration=client_configuration,
                                persist_config=persist_config,
                                temp_file_path=temp_file_path)
-    return ApiClient(configuration=client_config)
+    return ApiClient(configuration=client_configuration)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Makes possible to provide a _client.configuration_ object to the function that creates new client api.
This allow to provide the same configuration when calling `config.load_kube_config()`and `config.new_client_from_config_dict(kubeconfig)`

Right now, the function _new_client_from_config_dict_ automatically creates a [new Configuration object](https://github.com/kubernetes-client/python/blob/5a96bbcbe21a552cc1f9cda13e0522fafb0dbac8/kubernetes/base/config/kube_config.py#L886)

#### Which issue(s) this PR fixes:
Fixes #1967 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added: "client.configuration" object as input of function "config.new_client_from_config_dict()"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
