### PR TITLE
doc: comment pod_exec.py for multiple containers

### DIFF
--- a/examples/pod_exec.py
+++ b/examples/pod_exec.py
@@ -71,6 +71,8 @@ def exec_commands(api_instance):
         '/bin/sh',
         '-c',
         'echo This message goes to stderr; echo This message goes to stdout']
+    # When calling a pod with multiple containers running the target container
+    # has to be specified with a keyword argument container=<name>.
     resp = stream(api_instance.connect_get_namespaced_pod_exec,
                   name,
                   'default',


### PR DESCRIPTION
The behavior in kubectl for an exec is to run the exec command against the default container if there are multiple
containers running in a pod (ie sidecars). However, the container needs to be specified with this python client call or
an error of kind **WebSocketBadStatusException** will be raised. Add a comment in the example to explain this.

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
**Document Side Car Container exec** 

Firstly a big thank you to the maintainers of the python kubernetes-client I hope to offer help going forwards but am 
revisiting python for the first time in a decade.

**Problem Description**

During the normal use of the [pod_exec.py](https://github.com/kubernetes-client/python/blob/master/examples/pod_exec.py) example it came to my attention that when executing against a pod with multiple containers (ie sidecars) a WebSocketBadStatusException was raised. To fix this a container , often annotated as *kubectl.kubernetes.io/default-container* would need to be specified in the call. (when using kubectl the behavior when in an exec is to target the default container in the pod)



```python
    resp = stream(api.connect_get_namespaced_pod_exec,
                  name=pod,
                  namespace='default',
                  command=exec_command,
                  container=container,
                  stdout=True, tty=False)
```
I found this out via the issue [1870](https://github.com/kubernetes-client/python/issues/1870). I want to help others so that they can find this fix without the pain I had. I am suggesting a comment in the existing example. An alternative would be an example of pod_exec_for_side_cars.py which would give an example of how to use this with a pod that has sidecars.

I would like to investigate the possibility of raising a better exception or targeting the default container in an exec call.

Reproduction Notes

I created a simple flask application and created an image from that tiny application. I Deployed this within a minikube 
cluster and followed the pod_exec.py example. I then installed [istio](https://istio.io/latest/docs/setup/getting-started/) 
onto my cluster and repeated the process. This time the pod_exec.py raised the exception.

- [this issue was tested with a simple flask application](https://github.com/ghinks/python_container_for_cloud)
- [flask application docker hub location](https://hub.docker.com/repository/docker/ghinks/python-for-cloud)
- [minikube service deployment to re-produce exception when no container is specified](https://github.com/ghinks/python-minikube-deployments)

#### Which issue(s) this PR fixes:
Documents case described in issue [1870](https://github.com/kubernetes-client/python/issues/1870) in the example to
avoid others falling into the same issue


#### Special notes for your reviewer:
I have been out of the Python ecosystem for a long while but have come back as I see advantages for the work I do with
GitOps applications. I would like to follow up on this code comment with possible changes via another PR that would raise a
different error or use the default container if possible. I'm still reading the code and am not ready for that yet.


#### Does this PR introduce a user-facing change?
no

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
