### PR TITLE
Dynamic Client Request Timeout Example

### DIFF
--- a/examples/dynamic-client/request_timeout.py
+++ b/examples/dynamic-client/request_timeout.py
@@ -1,0 +1,70 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This example demonstrates the following:
+    - Creation of a k8s configmap using dynamic-client
+    - Setting the request timeout which is time duration in seconds
+"""
+
+from kubernetes import config, dynamic
+from kubernetes.client import api_client
+
+
+def main():
+    # Creating a dynamic client
+    client = dynamic.DynamicClient(
+        api_client.ApiClient(configuration=config.load_kube_config())
+    )
+
+    # fetching the configmap api
+    api = client.resources.get(api_version="v1", kind="ConfigMap")
+
+    configmap_name = "request-timeout-test-configmap"
+
+    configmap_manifest = {
+        "kind": "ConfigMap",
+        "apiVersion": "v1",
+        "metadata": {
+            "name": configmap_name,
+            "labels": {
+                "foo": "bar",
+            },
+        },
+        "data": {
+            "config.json": '{"command":"/usr/bin/mysqld_safe"}',
+            "frontend.cnf": "[mysqld]\nbind-address = 10.0.0.3\n",
+        },
+    }
+
+    # Creating configmap `request-timeout-test-configmap` in the `default` namespace
+    # Client-side timeout to 60 seconds
+
+    configmap = api.create(body=configmap_manifest, namespace="default", _request_time=60)
+
+    print("\n[INFO] configmap `request-timeout-test-configmap` created\n")
+
+    # Listing the configmaps in the `default` namespace
+    # Client-side timeout to 60 seconds
+
+    configmap_list = api.get(
+        name=configmap_name, namespace="default", label_selector="foo=bar", _request_time=60
+    )
+
+    print("NAME:\n%s\n" % (configmap_list.metadata.name))
+    print("DATA:\n%s\n" % (configmap_list.data))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/watch/timeout-settings.md
+++ b/examples/watch/timeout-settings.md
@@ -56,6 +56,9 @@ There are two inputs available in the client, that could be used to set connecti
   ***Refer***
   - *[https://github.com/kubernetes-client/python/blob/v17.17.0/kubernetes/client/api_client.py#L336-L339](https://github.com/kubernetes-client/python/blob/v17.17.0/kubernetes/client/api_client.py#L336-L339)*
 
+  ***Example***
+  - *[request_timeout.py](../dynamic-client/request_timeout.py)*
+ 
 - In case of network outage, leading to dropping all packets with no RST/FIN, the timeout value (in seconds) determined by the `request_timeout` argument, would be the time duration for how long the client will wait before dropping the connection.
 
 - When the timeout happens, an exception will be raised, for eg. ~


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation


#### What this PR does / why we need it:
This is more on providing an example on how to use _request_time for dynamic client.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes-client/python/issues/1978

Special notes for your reviewer: None

#### Does this PR introduce a user-facing change?
NONE

```release-note
 Dynamic client example for client side request timeout argument.
```
