### PR TITLE
Remove erroneous runtime dependence on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,9 @@ with open('requirements.txt') as f:
     for line in f:
         line, _, _ = line.partition('#')
         line = line.strip()
-        if ';' in line:
+        if not line or line.startswith('setuptools'):
+            continue
+        elif ';' in line:
             requirement, _, specifier = line.partition(';')
             for_specifier = EXTRAS.setdefault(':{}'.format(specifier), [])
             for_specifier.append(requirement)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The code base as far as I can tell does not use `setuptools` at runtime and therefore this reduces the installation footprint and potential memory implications from unknown transitive dependencies attempting to import it

#### Which issue(s) this PR fixes:

Fixes #2021

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: