### PR TITLE
Fix pod_namespace_watch example

### DIFF
--- a/examples/watch/pod_namespace_watch.py
+++ b/examples/watch/pod_namespace_watch.py
@@ -44,6 +44,7 @@ def main():
             w.stop()
     print("Finished namespace stream.")
 
+    count = 10
     for event in w.stream(v1.list_pod_for_all_namespaces, timeout_seconds=10):
         print("Event: %s %s %s" % (
             event['type'],


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The documentation of this example code says:
> The script will wait for 10 events related to namespaces to occur within
the `timeout_seconds` threshold and then move on to **wait for another 10 events**
related to pods to occur within the `timeout_seconds` threshold.

To wait for another 10 events this counter must be set again.

#### Does this PR introduce a user-facing change?

NONE
