### PR TITLE
fix deprecation warn for HTTPResponse.getheaders()

### DIFF
--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -41,11 +41,11 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.getdefault(name, default)
 
 
 class RESTClientObject(object):


### PR DESCRIPTION
Running the Kubernetes python client sometimes results in deprecation warnings being shown like this:

```
DeprecationWarning: HTTPResponse.getheaders() is deprecated and will be removed in urllib3 v2.1.0. Instead access HTTPResponse.headers directly.
```

This patch addresses this deprecation warning by accessing the HTTPResponse.headers field (which is a dict) directly.

Issue #2024

/kind cleanup
/kind deprecation