### PR TITLE
Prevent ConstructorError when parsing YAML containing '=' scalars

### DIFF
--- a/kubernetes/utils/create_from_yaml.py
+++ b/kubernetes/utils/create_from_yaml.py
@@ -153,12 +153,17 @@ def create_from_yaml(
             raise FailToCreateError(failures)
         return k8s_objects
 
+    class Loader(yaml.loader.SafeLoader):
+        yaml_implicit_resolvers = yaml.loader.SafeLoader.yaml_implicit_resolvers.copy()
+        if "=" in yaml_implicit_resolvers:
+            yaml_implicit_resolvers.pop("=")
+
     if yaml_objects:
         yml_document_all = yaml_objects
         return create_with(yml_document_all)
     elif yaml_file:
         with open(os.path.abspath(yaml_file)) as f:
-            yml_document_all = yaml.safe_load_all(f)
+            yml_document_all = yaml.load_all(f, Loader=Loader)
             return create_with(yml_document_all)
     else:
         raise ValueError(


### PR DESCRIPTION
pyyaml assignes '=' to tag:yaml.org,2002:value even though there's no constructor for it. Removing the implicit resolver for '=' fixes the issue.

#### What type of PR is this?

/kind bug
#### What this PR does / why we need it:

Currently applying YAML documents containing the `=` scalar results in an error. Minimal example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: demo
data:
  equal: =
```

```python
from kubernetes import client, config, utils


def main():
    config.load_kube_config()
    k8s_client = client.ApiClient()
    yaml_file = "configmap.yml"
    utils.create_from_yaml(k8s_client, yaml_file, verbose=True)


if __name__ == "__main__":
    main()

```

results in:

```
yaml.constructor.ConstructorError: could not determine a constructor for the tag 'tag:yaml.org,2002:value'
  in "/home/juergen/ghq/github.com/kubernetes-client/python/configmap.yml", line 6, column 10
```

While the above example is contrived, this issue also  [hit me in real world when parsing the Prometheus operator CRD](https://github.com/yaml/pyyaml/issues/619) 




```release-note
NONE
```

