### PR TITLE
Fix exception in ExecProvider when no console is attached.

### DIFF
--- a/kubernetes/base/config/exec_provider.py
+++ b/kubernetes/base/config/exec_provider.py
@@ -53,11 +53,11 @@ class ExecProvider(object):
                 value = item['value']
                 additional_vars[name] = value
             self.env.update(additional_vars)
-        
+
         self.cwd = cwd or None
 
     def run(self, previous_response=None):
-        is_interactive = sys.stdout.isatty()
+        is_interactive = hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
         kubernetes_exec_info = {
             'apiVersion': self.api_version,
             'kind': 'ExecCredential',

--- a/kubernetes/base/config/exec_provider_test.py
+++ b/kubernetes/base/config/exec_provider_test.py
@@ -149,6 +149,19 @@ class ExecProviderTest(unittest.TestCase):
         ep.run()
         self.assertEqual(mock.call_args[1]['cwd'], '/some/directory')
 
+    @mock.patch('subprocess.Popen')
+    def test_ok_no_console_attached(self, mock):
+        instance = mock.return_value
+        instance.wait.return_value = 0
+        instance.communicate.return_value = (self.output_ok, '')
+        mock_stdout = unittest.mock.patch(
+            'sys.stdout', new=None)  # Simulate detached console
+        with mock_stdout:
+            ep = ExecProvider(self.input_ok, None)
+            result = ep.run()
+            self.assertTrue(isinstance(result, dict))
+            self.assertTrue('token' in result)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

There are scenarios in python where sys.stdout can be None, for example when a python application is compiled with PyInstaller, or used in a TUI (text-based user-interface) application e.g. Textual.  This is mentioned in the python docs here:

https://docs.python.org/3/library/sys.html#sys.__stdout__

> Note Under some conditions stdin, stdout and stderr as well as the original values __stdin__, __stdout__ and __stderr__ can be None. It is usually the case for Windows GUI apps that aren’t connected to a console and Python apps started with pythonw.

This PR allows ExecProvider to work in such scenarios as these.  

#### Which issue(s) this PR fixes:

Fixes #1986 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```NONE```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
