### PR TITLE
Fix dynamic client watch of named resource

### DIFF
--- a/kubernetes/base/dynamic/client.py
+++ b/kubernetes/base/dynamic/client.py
@@ -195,10 +195,13 @@ class DynamicClient(object):
         """
         if not watcher: watcher = watch.Watch()
 
+        # Use field selector to query for named instance so the watch parameter is handled properly.
+        if name:
+            field_selector = f"metadata.name={name}"
+
         for event in watcher.stream(
             resource.get,
             namespace=namespace,
-            name=name,
             field_selector=field_selector,
             label_selector=label_selector,
             resource_version=resource_version,

--- a/kubernetes/base/dynamic/test_client.py
+++ b/kubernetes/base/dynamic/test_client.py
@@ -468,6 +468,11 @@ class TestDynamicClient(unittest.TestCase):
             name=name, namespace='default', label_selector="e2e-test=true")
         self.assertEqual(name, resp.metadata.name)
 
+        count = 0
+        for _ in client.watch(api, timeout=10, namespace="default", name=name):
+            count += 1
+        self.assertTrue(count > 0, msg="no events received for watch")
+
         test_configmap['data']['config.json'] = "{}"
         resp = api.patch(
             name=name, namespace='default', body=test_configmap)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR fixes a problem the DynamicClient `watch` method which has a `name` parameter to specify a specific resource to watch.  This causes KeyError exceptions in watch.unmarshal_event because the API returns the named resource and ignores the `watch` parameter.  The change converts the `name` parameter to `fieldSelector="metadata.name=foo"` before calling the `watch.stream()` method.

#### Which issue(s) this PR fixes:
Fixes #1484 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix dynamic client watch of named resource
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
