### PR TITLE
Drop urllib3 upper bound

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.* # LGPLv2+
 requests # Apache-2.0
 requests-oauthlib # ISC
 oauthlib>=3.2.2 # BSD
-urllib3>=1.24.2,<2.0  # MIT
+urllib3>=1.24.2  # MIT


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This bound was added in https://github.com/kubernetes-client/python/commit/27459d5c123c20b096d838ebb98e735134a2a981.

Note that google-auth now requires urllib3>=2 in https://github.com/googleapis/google-auth-library-python/pull/1389

(I'm also not sure that I follow the logic in https://github.com/kubernetes-client/python/pull/2105, since dependency resolvers would have been able to work out a compatible set of packages based on google-auth's dependencies without propagating the bound into this project)

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-client/python/issues/2129

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```