### PR TITLE
remove deprecated IOError

### DIFF
--- a/kubernetes/base/config/kube_config_test.py
+++ b/kubernetes/base/config/kube_config_test.py
@@ -372,7 +372,7 @@ class FakeConfig:
                         with open(v) as f1, open(other.__dict__[k]) as f2:
                             if f1.read() != f2.read():
                                 return
-                    except IOError:
+                    except OSError:
                         # fall back to only compare filenames in case we are
                         # testing the passing of filenames to the config
                         if other.__dict__[k] != v:
@@ -393,7 +393,7 @@ class FakeConfig:
                 try:
                     with open(v) as f:
                         val = "FILE: %s" % str.decode(f.read())
-                except IOError as e:
+                except OSError as e:
                     val = "ERROR: %s" % str(e)
             rep += "\t%s: %s\n" % (k, val)
         return "Config(%s\n)" % rep


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Since python version 3.3 IOError has been deprecated and merged (with other various exceptions) into a OSError.

#### Special notes for your reviewer:
n/a

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
