### PR TITLE
Return empty list when there is no matching resource instsnce items  …

### DIFF
--- a/kubernetes/base/dynamic/resource.py
+++ b/kubernetes/base/dynamic/resource.py
@@ -291,6 +291,8 @@ class ResourceInstance(object):
         kind = instance['kind']
         if kind.endswith('List') and 'items' in instance:
             kind = instance['kind'][:-4]
+            if not instance['items']:
+                instance['items'] = []
             for item in instance['items']:
                 if 'apiVersion' not in item:
                     item['apiVersion'] = instance['apiVersion']


### PR DESCRIPTION
What type of PR is this?

/kind bug

When using dynamic client to list pods in PartialObjectMetadataList format. When there no matching pods with labels, its throwing exception rather than return empty list. This MR will return empty list instead of throwing exception.

Fixes: https://github.com/kubernetes-client/python/issues/2142

Special notes for your reviewer:

Return default empty list when there is nothing to return

Does this PR introduce a user-facing change?

No

It gracefully return empty list when there is matching resources


#fetching the node api
api = client.resources.get(api_version="v1", kind="Pod")

#Creating a custom header
params = {'header_params': {'Accept': 'application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io'}, 'query_params': [('labelSelector', 'role=xyz')], 'namespace': 'default'}

resp = api.get(**params)
Traceback (most recent call last):
File "dynamic_client.py", line 30, in 
main()
File "dynamic_client.py", line 16, in main
resp = api.get(**params)
File "/usr/local/miniconda/lib/python3.7/site-packages/kubernetes/dynamic/client.py", line 112, in get
return self.request('get', path, **kwargs)
File "/usr/local/miniconda/lib/python3.7/site-packages/kubernetes/dynamic/client.py", line 62, in inner
return serializer(self, json.loads(resp.data.decode('utf8')))
File "/usr/local/miniconda/lib/python3.7/site-packages/kubernetes/dynamic/resource.py", line 291, in init
for item in instance['items']:
TypeError: 'NoneType' object is not iterable