### PR TITLE
Provides a patch to stop using urllib3 deprecated APIs until the upgrade to latest OpenAPI Generator (>6.4.0)

### DIFF
--- a/scripts/rest_urllib_headers.diff
+++ b/scripts/rest_urllib_headers.diff
@@ -1,0 +1,13 @@
+diff --git a/kubernetes/client/exceptions.py b/kubernetes/client/exceptions.py
+index c7c152b5..1e23d80a 100644
+--- a/kubernetes/client/exceptions.py
++++ b/kubernetes/client/exceptions.py
+@@ -88,7 +88,7 @@ class ApiException(OpenApiException):
+             self.status = http_resp.status
+             self.reason = http_resp.reason
+             self.body = http_resp.data
+-            self.headers = http_resp.getheaders()
++            self.headers = http_resp.headers
+         else:
+             self.status = status
+             self.reason = reason

--- a/scripts/update-client.sh
+++ b/scripts/update-client.sh
@@ -78,6 +78,8 @@ git apply "${SCRIPT_ROOT}/rest_client_patch.diff"
 # once we upgrade to a version of swagger-codegen that includes it (version>= 6.6.0).
 # See https://github.com/OpenAPITools/openapi-generator/pull/15283
 git apply "${SCRIPT_ROOT}/rest_sni_patch.diff"
+# OpenAPI client generator prior to 6.4.0 uses deprecated urllib3 APIs.
+git apply "${SCRIPT_ROOT}/rest_urllib_headers.diff"
 
 echo ">>> generating docs..."
 pushd "${DOC_ROOT}" > /dev/null


### PR DESCRIPTION
This is a fix for #2169, continued from #2170  
@yliaog

#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:
Provides a patch to stop using urllib3 deprecated APIs until the upgrade to latest OpenAPI Generator (>6.4.0)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2169

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

```release-note
Provides a patch to stop using urllib3 deprecated APIs until the upgrade to latest OpenAPI Generator (>6.4.0)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
