### PR TITLE
Replace deprecated assertEquals call

### DIFF
--- a/kubernetes/base/config/kube_config_test.py
+++ b/kubernetes/base/config/kube_config_test.py
@@ -1615,7 +1615,7 @@ class TestKubeConfigLoader(BaseTestCase):
         actual = _get_kube_config_loader(filename=config_file,
                                          persist_config=True)
         self.assertTrue(callable(actual._config_persister))
-        self.assertEquals(actual._config_persister.__name__, "save_changes")
+        self.assertEqual(actual._config_persister.__name__, "save_changes")
 
     def test__get_kube_config_loader_dict_no_persist(self):
         expected = FakeConfig(host=TEST_HOST,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### Special notes for your reviewer:

Python 3.12 removed the `unittest.assertEquals` method which was deprecated since Python 3.2 and 2.7. The proper method is without the  `s` at the end. https://docs.python.org/3.11/library/unittest.html#deprecated-aliases, https://docs.python.org/2.7/library/unittest.html#deprecated-aliases

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
