### PR TITLE
pick proxy from kube_config

### DIFF
--- a/kubernetes/base/config/kube_config.py
+++ b/kubernetes/base/config/kube_config.py
@@ -569,6 +569,8 @@ class KubeConfigLoader(object):
             self.verify_ssl = not self._cluster['insecure-skip-tls-verify']
         if 'tls-server-name' in self._cluster:
             self.tls_server_name = self._cluster['tls-server-name']
+        if 'proxy-url' in self._cluster:
+            self.proxy = self._cluster['proxy-url']
 
     def _set_config(self, client_configuration):
         if 'token' in self.__dict__:
@@ -580,7 +582,7 @@ class KubeConfigLoader(object):
                 self._set_config(client_configuration)
             client_configuration.refresh_api_key_hook = _refresh_api_key
         # copy these keys directly from self to configuration object
-        keys = ['host', 'ssl_ca_cert', 'cert_file', 'key_file', 'verify_ssl','tls_server_name']
+        keys = ['host', 'ssl_ca_cert', 'cert_file', 'key_file', 'verify_ssl', 'tls_server_name', 'proxy']
         for key in keys:
             if key in self.__dict__:
                 setattr(client_configuration, key, getattr(self, key))

--- a/kubernetes/base/config/kube_config_test.py
+++ b/kubernetes/base/config/kube_config_test.py
@@ -104,6 +104,8 @@ TEST_CLIENT_CERT = "client-cert"
 TEST_CLIENT_CERT_BASE64 = _base64(TEST_CLIENT_CERT)
 TEST_TLS_SERVER_NAME = "kubernetes.io"
 
+TEST_PROXY_URL = "http://localhost:8888"
+
 TEST_OIDC_TOKEN = "test-oidc-token"
 TEST_OIDC_INFO = "{\"name\": \"test\"}"
 TEST_OIDC_BASE = ".".join([
@@ -552,6 +554,12 @@ class TestKubeConfigLoader(BaseTestCase):
                 }
             },
             {
+                "name": "proxy",
+                "context": {
+                    "cluster": "proxy",
+                }
+            },
+            {
                 "name": "non_existing_user",
                 "context": {
                     "cluster": "default",
@@ -650,6 +658,12 @@ class TestKubeConfigLoader(BaseTestCase):
                         TEST_CERTIFICATE_AUTH_BASE64,
                     "insecure-skip-tls-verify": False,
                     "tls-server-name": TEST_TLS_SERVER_NAME,
+                }
+            },
+            {
+                "name": "proxy",
+                "cluster": {
+                    "proxy-url": TEST_PROXY_URL,
                 }
             },
         ],
@@ -1282,6 +1296,16 @@ class TestKubeConfigLoader(BaseTestCase):
         KubeConfigLoader(
             config_dict=self.TEST_KUBE_CONFIG,
             active_context="tls-server-name").load_and_set(actual)
+        self.assertEqual(expected, actual)
+
+    def test_proxy_server(self):
+        expected = FakeConfig(
+            proxy=TEST_PROXY_URL
+        )
+        actual = FakeConfig()
+        KubeConfigLoader(
+            config_dict=self.TEST_KUBE_CONFIG,
+            active_context="proxy").load_and_set(actual)
         self.assertEqual(expected, actual)
 
     def test_list_contexts(self):


### PR DESCRIPTION

#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
kubeconfig support the option [proxy-url](https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/#Cluster) .
This is option is ignored by this client. and people have trouble to configer there proxy #1967
This pull request will use that option to set `kubernetes.client.load_kube_config()' to set `kubernetes.client.configuration.proxy` 

#### Which issue(s) this PR fixes:

Fixes #2183

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`load_kube_config`, ` new_client_from_config_dict`, `new_client_from_config` will use `proxy-url` cluster setting to `set client..configuration.proxy`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
