### PR TITLE
Fix merging current-context in kube-configs

### DIFF
--- a/kubernetes/base/config/kube_config.py
+++ b/kubernetes/base/config/kube_config.py
@@ -727,6 +727,10 @@ class KubeConfigMerger:
             self.config_merged = ConfigNode(path, config_merged, path)
         for item in ('clusters', 'contexts', 'users'):
             self._merge(item, config.get(item, []) or [], path)
+
+        if 'current-context' in config:
+            self.config_merged.value['current-context'] = config['current-context']
+
         self.config_files[path] = config
 
     def _merge(self, item, add_cfg, path):


### PR DESCRIPTION
#### What type of PR is this?

It fixes merging kube configs when current-context is not defined in the first config.

/kind bug

#### What this PR does / why we need it:

To merge multiple kube configs in the same way as kubectl does.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-client/python/issues/2180

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix bug related to merging context when multiple kubeconfigs are provided.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
