### PR TITLE
remove ipaddress from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ python-dateutil>=2.5.3  # BSD
 setuptools>=21.0.0  # PSF/ZPL
 pyyaml>=5.4.1  # MIT
 google-auth>=1.0.1  # Apache-2.0
-ipaddress>=1.0.17;python_version=="2.7"  # PSF
 websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.* # LGPLv2+
 requests # Apache-2.0
 requests-oauthlib # ISC


### PR DESCRIPTION
#### What type of PR is this?

This PR removes `ipaddress` from requirements.txt. It was necessary for python 2.7 (not supported), now this library is a part of Python 3.x.

/kind cleanup

#### What this PR does / why we need it:

Clean up unused requirements.

#### Which issue(s) this PR fixes:

Fixes #2185

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

