### PR TITLE
Don't delete all nodes when empty string is passed

### DIFF
--- a/scripts/core_v1_api.diff
+++ b/scripts/core_v1_api.diff
@@ -1,0 +1,16 @@
+diff --git a/kubernetes/client/api/core_v1_api.py b/kubernetes/client/api/core_v1_api.py
+index 282d9b88..8de09a11 100644
+--- a/kubernetes/client/api/core_v1_api.py
++++ b/kubernetes/client/api/core_v1_api.py
+@@ -13680,7 +13680,10 @@ class CoreV1Api(object):
+         del local_var_params['kwargs']
+         # verify the required parameter 'name' is set
+         if self.api_client.client_side_validation and ('name' not in local_var_params or  # noqa: E501
+-                                                        local_var_params['name'] is None):  # noqa: E501
++                                                        local_var_params['name'] is None or  # noqa: E501
++                                                        not len(local_var_params['name'].strip())):  # noqa: E501
++            raise ApiValueError("Missing the required parameter `name` when calling `delete_node`")  # noqa: E501
++        if not len(name):
+             raise ApiValueError("Missing the required parameter `name` when calling `delete_node`")  # noqa: E501
+ 
+         collection_formats = {}

--- a/scripts/update-client.sh
+++ b/scripts/update-client.sh
@@ -80,6 +80,8 @@ git apply "${SCRIPT_ROOT}/rest_client_patch.diff"
 git apply "${SCRIPT_ROOT}/rest_sni_patch.diff"
 # OpenAPI client generator prior to 6.4.0 uses deprecated urllib3 APIs.
 git apply "${SCRIPT_ROOT}/rest_urllib_headers.diff"
+# Delete Node fix for empty string
+git apply "${SCRIPT_ROOT}/core_v1_api.diff"
 
 echo ">>> generating docs..."
 pushd "${DOC_ROOT}" > /dev/null


### PR DESCRIPTION
Fixed a bug that allows an empty string for a node name when calling the `delete_node`/`delete_node_with_http_info` method.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

https://github.com/kubernetes-client/python/issues/2209 explains the issue well.

#### Which issue(s) this PR fixes:
Fixes #2209 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

