### PR TITLE
replace utcnow with now, due to utcnow will be deprecated

### DIFF
--- a/examples/deployment_crud.py
+++ b/examples/deployment_crud.py
@@ -108,8 +108,7 @@ def restart_deployment(api, deployment):
     # update `spec.template.metadata` section
     # to add `kubectl.kubernetes.io/restartedAt` annotation
     deployment.spec.template.metadata.annotations = {
-        "kubectl.kubernetes.io/restartedAt": datetime.datetime.utcnow()
-        .replace(tzinfo=pytz.UTC)
+        "kubectl.kubernetes.io/restartedAt": datetime.datetime.now(tz=pytz.UTC)
         .isoformat()
     }
 

--- a/examples/dynamic-client/deployment_rolling_restart.py
+++ b/examples/dynamic-client/deployment_rolling_restart.py
@@ -84,8 +84,7 @@ def main():
 
     deployment_manifest["spec"]["template"]["metadata"] = {
         "annotations": {
-            "kubectl.kubernetes.io/restartedAt": datetime.datetime.utcnow()
-            .replace(tzinfo=pytz.UTC)
+            "kubectl.kubernetes.io/restartedAt": datetime.datetime.now(tz=pytz.UTC)
             .isoformat()
         }
     }

--- a/kubernetes/base/config/kube_config.py
+++ b/kubernetes/base/config/kube_config.py
@@ -80,7 +80,7 @@ def _create_temp_file_with_content(content, temp_file_path=None):
 
 def _is_expired(expiry):
     return ((parse_rfc3339(expiry) - EXPIRY_SKEW_PREVENTION_DELAY) <=
-            datetime.datetime.utcnow().replace(tzinfo=UTC))
+            datetime.datetime.now(tz=UTC))
 
 
 class FileOrData(object):

--- a/kubernetes/base/config/kube_config_test.py
+++ b/kubernetes/base/config/kube_config_test.py
@@ -30,7 +30,7 @@ from six import PY3, next
 from kubernetes.client import Configuration
 
 from .config_exception import ConfigException
-from .dateutil import format_rfc3339, parse_rfc3339
+from .dateutil import UTC, format_rfc3339, parse_rfc3339
 from .kube_config import (ENV_KUBECONFIG_PATH_SEPARATOR, CommandTokenSource,
                           ConfigNode, FileOrData, KubeConfigLoader,
                           KubeConfigMerger, _cleanup_temp_files,
@@ -89,10 +89,10 @@ TEST_USERNAME = "me"
 TEST_PASSWORD = "pass"
 # token for me:pass
 TEST_BASIC_TOKEN = "Basic bWU6cGFzcw=="
-DATETIME_EXPIRY_PAST = datetime.datetime.utcnow(
-) - datetime.timedelta(minutes=PAST_EXPIRY_TIMEDELTA)
-DATETIME_EXPIRY_FUTURE = datetime.datetime.utcnow(
-) + datetime.timedelta(minutes=FUTURE_EXPIRY_TIMEDELTA)
+DATETIME_EXPIRY_PAST = datetime.datetime.now(tz=UTC
+                                             ).replace(tzinfo=None) - datetime.timedelta(minutes=PAST_EXPIRY_TIMEDELTA)
+DATETIME_EXPIRY_FUTURE = datetime.datetime.now(tz=UTC
+                                               ).replace(tzinfo=None) + datetime.timedelta(minutes=FUTURE_EXPIRY_TIMEDELTA)
 TEST_TOKEN_EXPIRY_PAST = _format_expiry_datetime(DATETIME_EXPIRY_PAST)
 
 TEST_SSL_HOST = "https://test-host"
@@ -1028,7 +1028,7 @@ class TestKubeConfigLoader(BaseTestCase):
     def test_load_gcp_token_with_refresh(self):
         def cred(): return None
         cred.token = TEST_ANOTHER_DATA_BASE64
-        cred.expiry = datetime.datetime.utcnow()
+        cred.expiry = datetime.datetime.now(tz=UTC)
 
         loader = KubeConfigLoader(
             config_dict=self.TEST_KUBE_CONFIG,
@@ -1123,7 +1123,6 @@ class TestKubeConfigLoader(BaseTestCase):
             config_dict=self.TEST_KUBE_CONFIG,
             active_context="expired_oidc_with_idp_ca_file",
         )
-
 
         self.assertTrue(loader._load_auth_provider_token())
         self.assertEqual("Bearer abc123", loader.token)
@@ -1529,6 +1528,7 @@ class TestKubeConfigLoader(BaseTestCase):
     @mock.patch('kubernetes.config.kube_config.ExecProvider.run', autospec=True)
     def test_user_exec_cwd(self, mock):
         capture = {}
+
         def capture_cwd(exec_provider):
             capture['cwd'] = exec_provider.cwd
         mock.side_effect = capture_cwd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

#### What this PR does / why we need it:
datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2213

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
