### PR TITLE
Typo in 'host configuration'

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -60,8 +60,6 @@ configuration.api_key['authorization'] = 'YOUR_API_KEY'
 # Defining host is optional and default to http://localhost
 configuration.host = "http://localhost"
 
-# Defining host is optional and default to http://localhost
-configuration.host = "http://localhost"
 # Enter a context with an instance of the API kubernetes.client
 with kubernetes.client.ApiClient(configuration) as api_client:
     # Create an instance of the API class


### PR DESCRIPTION
/kind documentation


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #
**I noticed that the part 'host configuration' was mistakenly repeated, so I went ahead and removed the duplicate occurrence to avoid any confusion.**

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
"NONE"  

/release-note-none

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
docs

