### PR TITLE
More GEP-2257 tweaks

### DIFF
--- a/examples/duration-gep2257.py
+++ b/examples/duration-gep2257.py
@@ -7,19 +7,19 @@ a GEP-2257 duration string (you can find the full specification at
 https://gateway-api.sigs.k8s.io/geps/gep-2257/).
 
 Good things to try:
->>> python examples/gep2257.py 1h
+>>> python examples/duration-gep2257.py 1h
 Duration: 1h
->>> python examples/gep2257.py 3600s
+>>> python examples/duration-gep2257.py 3600s
 Duration: 1h
->>> python examples/gep2257.py 90m
+>>> python examples/duration-gep2257.py 90m
 Duration: 1h30m
->>> python examples/gep2257.py 30m1h10s5s
+>>> python examples/duration-gep2257.py 30m1h10s5s
 Duration: 1h30m15s
->>> python examples/gep2257.py 0h0m0s0ms
+>>> python examples/duration-gep2257.py 0h0m0s0ms
 Duration: 0s
->>> python examples/gep2257.py -5m
+>>> python examples/duration-gep2257.py -5m
 ValueError: Invalid duration format: -5m
->>> python examples/gep2257.py 1.5h
+>>> python examples/duration-gep2257.py 1.5h
 ValueError: Invalid duration format: 1.5h
 """
 

--- a/examples/gep2257.py
+++ b/examples/gep2257.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+# -*- coding:utf-8 -*-
+
+"""
+This example uses kubernetes.utils.duration to parse and display
+a GEP-2257 duration string (you can find the full specification at
+https://gateway-api.sigs.k8s.io/geps/gep-2257/).
+
+Good things to try:
+>>> python examples/gep2257.py 1h
+Duration: 1h
+>>> python examples/gep2257.py 3600s
+Duration: 1h
+>>> python examples/gep2257.py 90m
+Duration: 1h30m
+>>> python examples/gep2257.py 30m1h10s5s
+Duration: 1h30m15s
+>>> python examples/gep2257.py 0h0m0s0ms
+Duration: 0s
+>>> python examples/gep2257.py -5m
+ValueError: Invalid duration format: -5m
+>>> python examples/gep2257.py 1.5h
+ValueError: Invalid duration format: 1.5h
+"""
+
+import sys
+
+from kubernetes.utils import duration
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: {} <duration>".format(sys.argv[0]))
+        sys.exit(1)
+
+    dur = duration.parse_duration(sys.argv[1])
+    print("Duration: %s" % duration.format_duration(dur))
+
+if __name__ == "__main__":
+    main()

--- a/kubernetes/utils/duration.py
+++ b/kubernetes/utils/duration.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import List
+
 import datetime
 import re
 
@@ -147,18 +149,26 @@ def format_duration(delta: datetime.timedelta) -> str:
             .format(delta)
         )
 
-    # Second short-circuit.
+    # After that, do the usual div & mod tree to take seconds and get hours,
+    # minutes, and seconds from it.
+    secs = int(delta.total_seconds())
 
-    delta -= datetime.timedelta(microseconds=delta_us)
-    delta_ms = delta_us // 1000
-    delta_str = durationpy.to_str(delta)
+    output: List[str] = []
 
-    if delta_ms > 0:
-        # We have milliseconds to add back in. Make sure to not have a leading
-        # "0" if we have no other duration components.
-        if delta == datetime.timedelta(0):
-            delta_str = ""
+    hours = secs // 3600
+    if hours > 0:
+        output.append(f"{hours}h")
+        secs -= hours * 3600
 
-        delta_str += f"{delta_ms}ms"
+    minutes = secs // 60
+    if minutes > 0:
+        output.append(f"{minutes}m")
+        secs -= minutes * 60
 
-    return delta_str
+    if secs > 0:
+        output.append(f"{secs}s")
+
+    if delta_us > 0:
+        output.append(f"{delta_us // 1000}ms")
+
+    return "".join(output)


### PR DESCRIPTION
This is best reviewed commit by commit.

First, refactor the formatter for GEP-2257 durations to just do things by hand rather than relying on durationpy's formatter. This is primarily a less fragile approach, but it also allows the three extant GEP-2257 implementations (Rust, Go, and Python) to be more similar.

Second, add an example program. Should've done this earlier.

/kind cleanup

```release-note
NONE
```
