### PR TITLE
Change examples/dynamic-client creation of DynamicClient to include configuration object that is not None

### DIFF
--- a/examples/dynamic-client/accept_header.py
+++ b/examples/dynamic-client/accept_header.py
@@ -22,12 +22,14 @@ from kubernetes.client import api_client
 
 def main():
     # Creating a dynamic client
-    client = dynamic.DynamicClient(
-        api_client.ApiClient(configuration=config.load_kube_config())
-    )
+    configuration = api_client.Configuration()
+    config.load_kube_config()
+    client = api_client.ApiClient(configuration=configuration)
+    dynamic_client = dynamic.DynamicClient(client)
+
 
     # fetching the node api
-    api = client.resources.get(api_version="v1", kind="Node")
+    api = dynamic_client.resources.get(api_version="v1", kind="Node")
 
     # Creating a custom header
     params = {'header_params': {'Accept': 'application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io'}}

--- a/examples/dynamic-client/cluster_scoped_custom_resource.py
+++ b/examples/dynamic-client/cluster_scoped_custom_resource.py
@@ -28,12 +28,13 @@ import time
 
 def main():
     # Creating a dynamic client
-    client = dynamic.DynamicClient(
-        api_client.ApiClient(configuration=config.load_kube_config())
-    )
+    configuration = api_client.Configuration()
+    config.load_kube_config()
+    client = api_client.ApiClient(configuration=configuration)
+    dynamic_client = dynamic.DynamicClient(client)
 
     # fetching the custom resource definition (CRD) api
-    crd_api = client.resources.get(
+    crd_api = dynamic_client.resources.get(
         api_version="apiextensions.k8s.io/v1", kind="CustomResourceDefinition"
     )
 
@@ -104,14 +105,14 @@ def main():
     # Fetching the "ingressroutes" CRD api
 
     try:
-        ingressroute_api = client.resources.get(
+        ingressroute_api = dynamic_client.resources.get(
             api_version="apps.example.com/v1", kind="IngressRoute"
         )
     except ResourceNotFoundError:
         # Need to wait a sec for the discovery layer to get updated
         time.sleep(2)
 
-    ingressroute_api = client.resources.get(
+    ingressroute_api = dynamic_client.resources.get(
         api_version="apps.example.com/v1", kind="IngressRoute"
     )
 

--- a/examples/dynamic-client/configmap.py
+++ b/examples/dynamic-client/configmap.py
@@ -24,12 +24,13 @@ from kubernetes.client import api_client
 
 def main():
     # Creating a dynamic client
-    client = dynamic.DynamicClient(
-        api_client.ApiClient(configuration=config.load_kube_config())
-    )
+    configuration = api_client.Configuration()
+    config.load_kube_config()
+    client = api_client.ApiClient(configuration=configuration)
+    dynamic_client = dynamic.DynamicClient(client)
 
     # fetching the configmap api
-    api = client.resources.get(api_version="v1", kind="ConfigMap")
+    api = dynamic_client.resources.get(api_version="v1", kind="ConfigMap")
 
     configmap_name = "test-configmap"
 

--- a/examples/dynamic-client/deployment_rolling_restart.py
+++ b/examples/dynamic-client/deployment_rolling_restart.py
@@ -27,12 +27,13 @@ import pytz
 
 def main():
     # Creating a dynamic client
-    client = dynamic.DynamicClient(
-        api_client.ApiClient(configuration=config.load_kube_config())
-    )
+    configuration = api_client.Configuration()
+    config.load_kube_config()
+    client = api_client.ApiClient(configuration=configuration)
+    dynamic_client = dynamic.DynamicClient(client)
 
     # fetching the deployment api
-    api = client.resources.get(api_version="apps/v1", kind="Deployment")
+    api = dynamic_client.resources.get(api_version="apps/v1", kind="Deployment")
 
     name = "nginx-deployment"
 

--- a/examples/dynamic-client/namespaced_custom_resource.py
+++ b/examples/dynamic-client/namespaced_custom_resource.py
@@ -62,12 +62,13 @@ def delete_namespace(namespace_api, name):
 
 def main():
     # Creating a dynamic client
-    client = dynamic.DynamicClient(
-        api_client.ApiClient(configuration=config.load_kube_config())
-    )
+    configuration = api_client.Configuration()
+    config.load_kube_config()
+    client = api_client.ApiClient(configuration=configuration)
+    dynamic_client = dynamic.DynamicClient(client)
 
     # fetching the custom resource definition (CRD) api
-    crd_api = client.resources.get(
+    crd_api = dynamic_client.resources.get(
         api_version="apiextensions.k8s.io/v1", kind="CustomResourceDefinition"
     )
 

--- a/examples/dynamic-client/node.py
+++ b/examples/dynamic-client/node.py
@@ -23,12 +23,14 @@ from kubernetes.client import api_client
 
 def main():
     # Creating a dynamic client
-    client = dynamic.DynamicClient(
-        api_client.ApiClient(configuration=config.load_kube_config())
-    )
+    
+    configuration = api_client.Configuration()
+    config.load_kube_config()
+    client = api_client.ApiClient(configuration=configuration)
+    dynamic_client = dynamic.DynamicClient(client)
 
     # fetching the node api
-    api = client.resources.get(api_version="v1", kind="Node")
+    api = dynamic_client.resources.get(api_version="v1", kind="Node")
 
     # Listing cluster nodes
 

--- a/examples/dynamic-client/replication_controller.py
+++ b/examples/dynamic-client/replication_controller.py
@@ -22,12 +22,13 @@ from kubernetes.client import api_client
 
 def main():
     # Creating a dynamic client
-    client = dynamic.DynamicClient(
-        api_client.ApiClient(configuration=config.load_kube_config())
-    )
+    configuration = api_client.Configuration()
+    config.load_kube_config()
+    client = api_client.ApiClient(configuration=configuration)
+    dynamic_client = dynamic.DynamicClient(client)
 
     # fetching the replication controller api
-    api = client.resources.get(api_version="v1", kind="ReplicationController")
+    api = dynamic_client.resources.get(api_version="v1", kind="ReplicationController")
 
     name = "frontend-replication-controller"
 

--- a/examples/dynamic-client/request_timeout.py
+++ b/examples/dynamic-client/request_timeout.py
@@ -24,12 +24,13 @@ from kubernetes.client import api_client
 
 def main():
     # Creating a dynamic client
-    client = dynamic.DynamicClient(
-        api_client.ApiClient(configuration=config.load_kube_config())
-    )
+    configuration = api_client.Configuration()
+    config.load_kube_config()
+    client = api_client.ApiClient(configuration=configuration)
+    dynamic_client = dynamic.DynamicClient(client)
 
     # fetching the configmap api
-    api = client.resources.get(api_version="v1", kind="ConfigMap")
+    api = dynamic_client.resources.get(api_version="v1", kind="ConfigMap")
 
     configmap_name = "request-timeout-test-configmap"
 

--- a/examples/dynamic-client/service.py
+++ b/examples/dynamic-client/service.py
@@ -24,12 +24,13 @@ from kubernetes.client import api_client
 
 def main():
     # Creating a dynamic client
-    client = dynamic.DynamicClient(
-        api_client.ApiClient(configuration=config.load_kube_config())
-    )
+    configuration = api_client.Configuration()
+    config.load_kube_config()
+    client = api_client.ApiClient(configuration=configuration)
+    dynamic_client = dynamic.DynamicClient(client)
 
     # fetching the service api
-    api = client.resources.get(api_version="v1", kind="Service")
+    api = dynamic_client.resources.get(api_version="v1", kind="Service")
 
     name = "frontend-service"
 


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Changed the examples to showcase DynamicClient instantiation without the parameter since `config.load_kube_config()` does not return anything. See more about this in https://github.com/kubernetes-client/python/issues/2279.

#### Which issue(s) this PR fixes:
Fixes #2279

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
