### PR TITLE
Remove mock from test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,6 @@ pytest-cov
 pluggy>=0.3.1
 py>=1.4.31
 randomize>=0.13
-mock>=2.0.0
 sphinx>=1.4 # BSD
 recommonmark
 sphinx_markdown_tables


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
I believe https://github.com/kubernetes-client/python/commit/f1dfdbba456f1aa53c06e9d063d54c9416f58010 made this dependency unnecessary. It ends up adding an extra unavailable dependency for EPEL packages preventing it from installing.

https://bugzilla.redhat.com/show_bug.cgi?id=2313896 has more information.