### PR TITLE
Make google-auth an optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ DEVELOPMENT_STATUS = "3 - Alpha"
 # http://pypi.python.org/pypi/setuptools
 
 EXTRAS = {
-    'adal': ['adal>=1.0.2']
+    'adal': ['adal>=1.0.2'],
+    'google-auth': ['google-auth>=1.0.0']  # Google Auth is now optional
 }
 REQUIRES = []
 with open('requirements.txt') as f:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

This PR makes the `google-auth` dependency optional, allowing users to install it only when needed. This change reduces the number of required dependencies, improving flexibility for users who don’t need Google authentication.

#### Which issue(s) this PR fixes:

fixes #2249

#### Special notes for your reviewer: NONE

#### Does this PR introduce a user-facing change?
```
Google authentication is now an optional dependency in the Kubernetes Python client.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
``` 
```

