### PR TITLE
Allow passing of custom pool manager

### DIFF
--- a/kubernetes/client/api_client.py
+++ b/kubernetes/client/api_client.py
@@ -66,13 +66,13 @@ class ApiClient(object):
     _pool = None
 
     def __init__(self, configuration=None, header_name=None, header_value=None,
-                 cookie=None, pool_threads=1):
+                 cookie=None, pool_threads=1, pool_manager=None):
         if configuration is None:
             configuration = Configuration.get_default_copy()
         self.configuration = configuration
         self.pool_threads = pool_threads
 
-        self.rest_client = rest.RESTClientObject(configuration)
+        self.rest_client = rest.RESTClientObject(configuration, pool_manager=pool_manager)
         self.default_headers = {}
         if header_name is not None:
             self.default_headers[header_name] = header_value

--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -50,12 +50,17 @@ class RESTResponse(io.IOBase):
 
 class RESTClientObject(object):
 
-    def __init__(self, configuration, pools_size=4, maxsize=None):
+    def __init__(self, configuration, pools_size=4, maxsize=None, pool_manager=None):
         # urllib3.PoolManager will pass all kw parameters to connectionpool
         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/poolmanager.py#L75  # noqa: E501
         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680  # noqa: E501
         # maxsize is the number of requests to host that are allowed in parallel  # noqa: E501
         # Custom SSL certificates and client certificates: http://urllib3.readthedocs.io/en/latest/advanced-usage.html  # noqa: E501
+
+        # Pre-created pool manager provided
+        if pool_manager is not None:
+            self.pool_manager = pool_manager
+            return
 
         # cert_reqs
         if configuration.verify_ssl:

--- a/scripts/rest_pool_manager.diff
+++ b/scripts/rest_pool_manager.diff
@@ -1,3 +1,23 @@
+diff --git a/kubernetes/client/api_client.py b/kubernetes/client/api_client.py
+index 53d94ce40..9db3eafad 100644
+--- a/kubernetes/client/api_client.py
++++ b/kubernetes/client/api_client.py
+@@ -66,13 +66,13 @@ class ApiClient(object):
+     _pool = None
+ 
+     def __init__(self, configuration=None, header_name=None, header_value=None,
+-                 cookie=None, pool_threads=1):
++                 cookie=None, pool_threads=1, pool_manager=None):
+         if configuration is None:
+             configuration = Configuration.get_default_copy()
+         self.configuration = configuration
+         self.pool_threads = pool_threads
+ 
+-        self.rest_client = rest.RESTClientObject(configuration)
++        self.rest_client = rest.RESTClientObject(configuration, pool_manager=pool_manager)
+         self.default_headers = {}
+         if header_name is not None:
+             self.default_headers[header_name] = header_value
 diff --git a/kubernetes/client/rest.py b/kubernetes/client/rest.py
 index 3e3b8b273..a5cee8d64 100644
 --- a/kubernetes/client/rest.py

--- a/scripts/rest_pool_manager.diff
+++ b/scripts/rest_pool_manager.diff
@@ -1,0 +1,24 @@
+diff --git a/kubernetes/client/rest.py b/kubernetes/client/rest.py
+index 3e3b8b273..a5cee8d64 100644
+--- a/kubernetes/client/rest.py
++++ b/kubernetes/client/rest.py
+@@ -50,13 +50,18 @@ class RESTResponse(io.IOBase):
+ 
+ class RESTClientObject(object):
+ 
+-    def __init__(self, configuration, pools_size=4, maxsize=None):
++    def __init__(self, configuration, pools_size=4, maxsize=None, pool_manager=None):
+         # urllib3.PoolManager will pass all kw parameters to connectionpool
+         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/poolmanager.py#L75  # noqa: E501
+         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680  # noqa: E501
+         # maxsize is the number of requests to host that are allowed in parallel  # noqa: E501
+         # Custom SSL certificates and client certificates: http://urllib3.readthedocs.io/en/latest/advanced-usage.html  # noqa: E501
+ 
++        # Pre-created pool manager provided
++        if pool_manager is not None:
++            self.pool_manager = pool_manager
++            return
++
+         # cert_reqs
+         if configuration.verify_ssl:
+             cert_reqs = ssl.CERT_REQUIRED

--- a/scripts/update-client.sh
+++ b/scripts/update-client.sh
@@ -82,6 +82,7 @@ git apply "${SCRIPT_ROOT}/rest_sni_patch.diff"
 # AttributeError: 'RESTResponse' object has no attribute 'headers'
 # OpenAPI client generator prior to 6.4.0 uses deprecated urllib3 APIs.
 # git apply "${SCRIPT_ROOT}/rest_urllib_headers.diff"
+git apply "${SCRIPT_ROOT}/rest_pool_manager.diff"
 
 echo ">>> generating docs..."
 pushd "${DOC_ROOT}" > /dev/null


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

(although from some perspectives it could be considered a bug!)

#### What this PR does / why we need it:

Summary: Then using the `load_kube_config` method, the python library is (apparently?!) unable to connect *securely* to a cluster where the cluster API endpoints are secured with CA certificates that have been signed by an internal/external CA authority (i.e. not self-signed).

Why is this? It seems that only the cluster CA gets stored in the `~/.kube/config` file, not the whole certificate chain. Therefore, the library can only resolve the chain if it is self-contained (self-signed). If it depends on additional certificates it will fail an exception something like this...

```
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='k8s-api.cluster.xyz', port=6443): Max retries exceeded with url: /api/v1/namespaces/vm-nodes/serviceaccounts (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get issuer certificate (_ssl.c:1000)')))
```

Issue: Currently, there does not seem to be any way to control the way the REST client `pool_manager` is created, and it's default configuration makes it impossible (AFAICS?!) to correctly/cleanly specify the CA chain to use.

#### Which issue(s) this PR fixes:

Fixes #2329

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Adds the ability to specify a custom CA chain for cases where the Kubernetes API is using externally-signed certificates.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
If you are using `load_kube_config` with a cluster that requires a certificate chain, you can supply a custom PoolManager that like this:

\`\`\`
    kubernetes.config.load_kube_config()
    custom_pool_manager = urllib3.PoolManager(
        cert_reqs="CERT_REQUIRED",
        ca_certs="/etc/ssl/certs/ca-certificates.crt"
    )
    api_client = kubernetes.client.ApiClient(pool_manager=custom_pool_manager)
    v1 = kubernetes.client.CoreV1Api(api_client)
\`\`\`

```
