### PR TITLE
Fix exec provider

### DIFF
--- a/kubernetes/base/config/exec_provider.py
+++ b/kubernetes/base/config/exec_provider.py
@@ -54,7 +54,7 @@ class ExecProvider(object):
                 additional_vars[name] = value
             self.env.update(additional_vars)
         if exec_config.safe_get('provideClusterInfo'):
-            self.cluster = cluster.value
+            self.cluster = cluster
         else:
             self.cluster = None
         self.cwd = cwd or None
@@ -71,7 +71,7 @@ class ExecProvider(object):
         if previous_response:
             kubernetes_exec_info['spec']['response'] = previous_response
         if self.cluster:
-            kubernetes_exec_info['spec']['cluster'] = self.cluster
+            kubernetes_exec_info['spec']['cluster'] = self.cluster.value
 
         self.env['KUBERNETES_EXEC_INFO'] = json.dumps(kubernetes_exec_info)
         process = subprocess.Popen(

--- a/kubernetes/base/config/exec_provider.py
+++ b/kubernetes/base/config/exec_provider.py
@@ -54,7 +54,7 @@ class ExecProvider(object):
                 additional_vars[name] = value
             self.env.update(additional_vars)
         if exec_config.safe_get('provideClusterInfo'):
-            self.cluster = cluster
+            self.cluster = cluster.value
         else:
             self.cluster = None
         self.cwd = cwd or None

--- a/kubernetes/base/config/exec_provider_test.py
+++ b/kubernetes/base/config/exec_provider_test.py
@@ -175,7 +175,7 @@ class ExecProviderTest(unittest.TestCase):
         instance = mock.return_value
         instance.wait.return_value = 0
         instance.communicate.return_value = (self.output_ok, '')
-        ep = ExecProvider(self.input_with_cluster, None, {'server': 'name.company.com'})
+        ep = ExecProvider(self.input_with_cluster, None, ConfigNode("cluster", {'server': 'name.company.com'}))
         result = ep.run()
         self.assertTrue(isinstance(result, dict))
         self.assertTrue('token' in result)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind regression

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
-->

#### What this PR does / why we need it:

The `ExecProvider` has a regression, probably due to 8c60fe94e06b8364d95cd35c22fdaf3177c1c564, resulting in broken auth when using the exec provider in provided kubeconfig.

#### Which issue(s) this PR fixes:

Fixes #2334

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes bug that would fail authentication when using the exec-provider with a specific cluster selected
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
