### PR TITLE
fix: Force Lease Expiration When Leader Exits

### DIFF
--- a/kubernetes/base/leaderelection/electionconfig.py
+++ b/kubernetes/base/leaderelection/electionconfig.py
@@ -16,10 +16,10 @@ import sys
 import logging
 logging.basicConfig(level=logging.INFO)
 
-
 class Config:
+
     # Validate config, exit if an error is detected
-    def __init__(self, lock, lease_duration, renew_deadline, retry_period, onstarted_leading, onstopped_leading):
+    def __init__(self, lock, lease_duration, renew_deadline, retry_period, onstarted_leading, onstopped_leading, context):
         self.jitter_factor = 1.2
 
         if lock is None:
@@ -53,6 +53,7 @@ class Config:
             self.onstopped_leading = self.on_stoppedleading_callback
         else:
             self.onstopped_leading = onstopped_leading
+        self.context = context
 
     # Default callback for when the current candidate if a leader, stops leading
     def on_stoppedleading_callback(self):

--- a/kubernetes/base/leaderelection/example.py
+++ b/kubernetes/base/leaderelection/example.py
@@ -14,10 +14,9 @@
 
 import uuid
 from kubernetes import client, config
-from kubernetes.leaderelection import leaderelection
-from kubernetes.leaderelection.resourcelock.configmaplock import ConfigMapLock
-from kubernetes.leaderelection import electionconfig
-
+import leaderelection
+from resourcelock.configmaplock import ConfigMapLock
+import electionconfig
 
 # Authenticate using config file
 config.load_kube_config(config_file=r"")
@@ -33,6 +32,8 @@ lock_name = "examplepython"
 # Kubernetes namespace
 lock_namespace = "default"
 
+context = leaderelection.Context()
+
 
 # The function that a user wants to run once a candidate is elected as a leader
 def example_func():
@@ -45,7 +46,7 @@ def example_func():
 # Create config
 config = electionconfig.Config(ConfigMapLock(lock_name, lock_namespace, candidate_id), lease_duration=17,
                                renew_deadline=15, retry_period=5, onstarted_leading=example_func,
-                               onstopped_leading=None)
+                               onstopped_leading=None, context=context)
 
 # Enter leader election
 leaderelection.LeaderElection(config).run()

--- a/kubernetes/base/leaderelection/resourcelock/configmaplock.py
+++ b/kubernetes/base/leaderelection/resourcelock/configmaplock.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import sys
+sys.path.append("..")
 from kubernetes.client.rest import ApiException
 from kubernetes import client, config
 from kubernetes.client.api_client import ApiClient
-from ..leaderelectionrecord import LeaderElectionRecord
+from leaderelectionrecord import LeaderElectionRecord
 import json
 import logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Currently, when the leader exits (say, after receiving a `SIGINT`), the workers need to wait for its lease to expire before a leader is re-elected. This patch mimics the behaviour of the Go Client implementation of using `ctx.Done()`: https://github.com/kubernetes/client-go/blob/1309f64d6648411b4a36a2f7fa84dd8df31884b6/tools/leaderelection/leaderelection.go#L265-L291. It captures the `SIGINT` and forces the lease to exit by setting the expiration to a date in the past, and it also sets the `acquire_time` to None to force a leader election.

- #### Issue Reproduction
    As mentioned in the issue: https://github.com/kubernetes-client/python/issues/2075, to reproduce this issue you can follow leaderelection/example.py. Run it on 2-3 nodes (or tmux screens), and once a leader is elected hit Ctrl+C to force the leader to exit. The workers then wait for the leader's lease to expire before a new leader is elected.

- #### Expected behavior
    The leader exiting should trigger a leader election without having the workers wait for the lease to expire.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-client/python/issues/2075

#### Special notes for your reviewer:

This is still not a complete fix, and it definitely hacky at the moment, and I would love any guidance here. Currently, the patch only handles `SIGINT`, but a leader may exit for various reasons, and there should be a more elegant way of handling this, probably using the thread context, but I was not able to figure that out. Further, the implementation of the `forceLeaseExpiration()` function is not elegant, you shouldn't need to set acquire_time to None and setting expiration to false is also a code smell in my opinion. This patch is a proof of concept because of this.

I also had to change the imports to point to my definitions of `electionconfig.py` and `leaderelectionrecord.py `for this to work, and I'm sure there is a better way of handling this. 

If its more sensible to mark this PR a draft, I'm happy to do so!

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
