### PR TITLE
Fix markdown preview for the V1EnvVar.md file

### DIFF
--- a/kubernetes/docs/V1EnvVar.md
+++ b/kubernetes/docs/V1EnvVar.md
@@ -5,7 +5,7 @@ EnvVar represents an environment variable present in a Container.
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** | Name of the environment variable. Must be a C_IDENTIFIER. | 
-**value** | **str** | Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \&quot;$$(VAR_NAME)\&quot; will produce the string literal \&quot;$(VAR_NAME)\&quot;. Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \&quot;\&quot;. | [optional] 
+**value** | **str** | Variable references `$(VAR_NAME)` are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double `$$` are reduced to a single $, which allows for escaping the `$(VAR_NAME)` syntax: i.e. `$$(VAR_NAME)` will produce the string literal `$(VAR_NAME)`. Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to `""`. | [optional] 
 **value_from** | [**V1EnvVarSource**](V1EnvVarSource.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)


### PR DESCRIPTION
#### What type of PR is this?

Fix for incorrect markdown preview
<img width="1144" alt="image" src="https://github.com/user-attachments/assets/5d1e9e51-9e0d-47c4-8971-91939b098431" />

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Incorrect markdown preview

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
