### PR TITLE
Add instructions for enabling debug logging in the Kubernetes Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,4 +236,20 @@ recreate it between api calls that use _stream_ and other api calls.
 
 See more at [exec example](examples/pod_exec.py).
 
+## Enabling Debug Logging
+
+To enable debug logging in the Kubernetes Python client, follow these steps:
+
+### 1. Import the `logging` module
+
+```python
+import logging
+
+# Set the logging level to DEBUG
+logging.basicConfig(level=logging.DEBUG)
+
+# To see the HTTP requests and responses sent to the Kubernetes API (for debugging network-related issues), configure the urllib3 logger:
+logging.getLogger("urllib3").setLevel(logging.DEBUG)
+```
+
 **[⬆ back to top](#Installation)**


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR adds a new section to the Kubernetes Python client README, explaining how to enable debug logging. The instructions show developers how to enable detailed logging for better debugging, particularly useful for inspecting HTTP requests and responses to the Kubernetes API, and troubleshooting network-related issues.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

This is a documentation-only change, providing helpful instructions for enabling debug logging in the Kubernetes Python client.

#### Does this PR introduce a user-facing change?

```release-note
Added instructions to enable debug logging using `logging` and `urllib3` in the Kubernetes Python client.
```