### PR TITLE
Modernize networking layer internals for future compatibility

### DIFF
--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -41,7 +41,7 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

This small PR updates the internal REST client's response handling (`kubernetes.client.rest.RESTResponse`) to address a `DeprecationWarning` originating from the `urllib3` library (version >= 2.0).

The underlying `urllib3.HTTPResponse.getheaders()` method is deprecated and scheduled for removal in `urllib3` v2.1.0. This PR replaces its usage with the recommended direct access to the `.headers` attribute.

This change resolves the deprecation warning observed during testing and ensures future compatibility of the Kubernetes Python client with upcoming versions of `urllib3`.

Warning example:
```python
/home/runner/work/python/python/kubernetes/client/rest.py:44: DeprecationWarning: HTTPResponse.getheaders() is deprecated and will be removed in urllib3 v2.1.0. Instead access HTTPResponse.headers directly.
```

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

This change directly addresses the `DeprecationWarning` concerning `HTTPResponse.getheaders()` as reported in CI logs and local testing. The fix involves switching from the deprecated `getheaders()` method call to accessing the `.headers` attribute on the underlying `urllib3` response object within our `RESTResponse` wrapper class.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE