### PR TITLE
feature: Socks proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kubernetes Python Client (bjoern)
+# Kubernetes Python Client
 
 [![Build Status](https://travis-ci.org/kubernetes-client/python.svg?branch=master)](https://travis-ci.org/kubernetes-client/python)
 [![PyPI version](https://badge.fury.io/py/kubernetes.svg)](https://badge.fury.io/py/kubernetes)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kubernetes Python Client
+# Kubernetes Python Client (bjoern)
 
 [![Build Status](https://travis-ci.org/kubernetes-client/python.svg?branch=master)](https://travis-ci.org/kubernetes-client/python)
 [![PyPI version](https://badge.fury.io/py/kubernetes.svg)](https://badge.fury.io/py/kubernetes)

--- a/kubernetes/base/stream/ws_client.py
+++ b/kubernetes/base/stream/ws_client.py
@@ -508,7 +508,7 @@ def websocket_proxycare(connect_opt, configuration, url, headers):
 
     if configuration.proxy:
         proxy_url = urlparse(configuration.proxy)
-        connect_opt.update({'http_proxy_host': proxy_url.hostname, 'http_proxy_port': proxy_url.port})
+        connect_opt.update({'http_proxy_host': proxy_url.hostname, 'http_proxy_port': proxy_url.port, 'proxy_type': proxy_url.scheme})
     if configuration.proxy_headers:
         for key,value in configuration.proxy_headers.items():
             if key == 'proxy-authorization' and value.startswith('Basic'):

--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -88,17 +88,31 @@ class RESTClientObject(object):
 
         # https pool manager
         if configuration.proxy and not should_bypass_proxies(configuration.host, no_proxy=configuration.no_proxy or ''):
-            self.pool_manager = urllib3.ProxyManager(
-                num_pools=pools_size,
-                maxsize=maxsize,
-                cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
-                cert_file=configuration.cert_file,
-                key_file=configuration.key_file,
-                proxy_url=configuration.proxy,
-                proxy_headers=configuration.proxy_headers,
-                **addition_pool_args
-            )
+            if configuration.proxy.startswith('sock'):
+                from urllib3.contrib.socks import SOCKSProxyManager
+                self.pool_manager = SOCKSProxyManager(
+                    num_pools=pools_size,
+                    maxsize=maxsize,
+                    cert_reqs=cert_reqs,
+                    ca_certs=ca_certs,
+                    cert_file=configuration.cert_file,
+                    key_file=configuration.key_file,
+                    proxy_url=configuration.proxy,
+                    headers=configuration.proxy_headers,
+                    **addition_pool_args
+                )
+            else:
+                self.pool_manager = urllib3.ProxyManager(
+                    num_pools=pools_size,
+                    maxsize=maxsize,
+                    cert_reqs=cert_reqs,
+                    ca_certs=ca_certs,
+                    cert_file=configuration.cert_file,
+                    key_file=configuration.key_file,
+                    proxy_url=configuration.proxy,
+                    proxy_headers=configuration.proxy_headers,
+                    **addition_pool_args
+                )
         else:
             self.pool_manager = urllib3.PoolManager(
                 num_pools=pools_size,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The client is missing support for proxies of type sock like socks5://localhost:1080

#### Which issue(s) this PR fixes:

https://github.com/kubernetes-client/python/issues/1064

*Automatically closes linked issue when PR is merged.
Usage: `Fixes #1064`

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adding support for socks proxies
```
