### PR TITLE
Fix: Prevent unintended pod listing on empty 'name' parameter in "read_namespaced_pod".

### DIFF
--- a/kubernetes/client/api/core_v1_api.py
+++ b/kubernetes/client/api/core_v1_api.py
@@ -24049,14 +24049,17 @@ class CoreV1Api(object):
                 )
             local_var_params[key] = val
         del local_var_params['kwargs']
-        # verify the required parameter 'name' is set
-        if self.api_client.client_side_validation and ('name' not in local_var_params or  # noqa: E501
-                                                        local_var_params['name'] is None):  # noqa: E501
-            raise ApiValueError("Missing the required parameter `name` when calling `read_namespaced_pod`")  # noqa: E501
-        # verify the required parameter 'namespace' is set
-        if self.api_client.client_side_validation and ('namespace' not in local_var_params or  # noqa: E501
-                                                        local_var_params['namespace'] is None):  # noqa: E501
-            raise ApiValueError("Missing the required parameter `namespace` when calling `read_namespaced_pod`")  # noqa: E501
+        # Verify the required parameter 'name' is set
+        if self.api_client.client_side_validation and ('name' not in local_var_params or local_var_params['name'] is None):
+            raise ApiValueError("Missing the required parameter `name` when calling `read_namespaced_pod`")
+
+        # Additional check to prevent empty string for 'name'
+        if self.api_client.client_side_validation and local_var_params.get('name') == "":
+            raise ApiValueError("Invalid value for parameter `name`: empty string is not allowed in read_namespaced_pod")
+
+        # Verify the required parameter 'namespace' is set
+        if self.api_client.client_side_validation and ('namespace' not in local_var_params or local_var_params['namespace'] is None):
+            raise ApiValueError("Missing the required parameter `namespace` when calling `read_namespaced_pod`")
 
         collection_formats = {}
 


### PR DESCRIPTION
… read_namespaced_pod

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

#### What this PR does/why we need it:
This PR fixes an issue where calling `read_namespaced_pod` with an empty string for the `name` parameter causes the Kubernetes Python client to fall back to the pod list endpoint. This behavior can lead to severe performance issues (such as OOMKills) in large clusters.

The fix adds an explicit validation check for an empty string value and raises an `ApiValueError`, ensuring the client fails early and predictably.

#### Which issue(s) this PR fixes:
Fixes #2382

#### Special notes for your reviewer:
The validation check was added in `read_namespaced_pod` around lines 24056–24058. Please confirm that the error behavior aligns with how other invalid parameters are handled in the client.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Calling `read_namespaced_pod` with an empty pod name now raises `ApiValueError` instead of silently listing all pods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
