### PR TITLE
feat: populate cluster config from client.authentication.k8s.io/exec …

### DIFF
--- a/kubernetes/base/config/exec_provider.py
+++ b/kubernetes/base/config/exec_provider.py
@@ -81,6 +81,10 @@ class ExecProvider(object):
             kubernetes_exec_info['spec']['response'] = previous_response
         if self.cluster:
             kubernetes_exec_info['spec']['cluster'] = self.cluster.value
+            for extension in self.cluster.value["extensions"]:
+                if extension["name"] == "client.authentication.k8s.io/exec":
+                    kubernetes_exec_info["spec"]["cluster"]["config"] = extension["extension"]
+                    break            
 
         self.env['KUBERNETES_EXEC_INFO'] = json.dumps(kubernetes_exec_info)
         process = subprocess.Popen(

--- a/kubernetes/base/config/exec_provider.py
+++ b/kubernetes/base/config/exec_provider.py
@@ -81,10 +81,11 @@ class ExecProvider(object):
             kubernetes_exec_info['spec']['response'] = previous_response
         if self.cluster:
             kubernetes_exec_info['spec']['cluster'] = self.cluster.value
-            for extension in self.cluster.value["extensions"]:
-                if extension["name"] == "client.authentication.k8s.io/exec":
-                    kubernetes_exec_info["spec"]["cluster"]["config"] = extension["extension"]
-                    break            
+            if self.cluster.value.get("extensions"):
+                for extension in self.cluster.value["extensions"]:
+                    if extension["name"] == "client.authentication.k8s.io/exec":
+                        kubernetes_exec_info["spec"]["cluster"]["config"] = extension["extension"]
+                        break
 
         self.env['KUBERNETES_EXEC_INFO'] = json.dumps(kubernetes_exec_info)
         process = subprocess.Popen(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

populate `ExecCredentialSpec.Cluster.config` from the client.authentication.k8s.io/exec extension

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2395 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds cluster config information to the exec credential provider if the client.authentication.k8s.io/exec extension is provided.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

Recreating PR since https://github.com/kubernetes-client/python/pull/2396 has CLA issues. Credits go to @wkloucek
