### PR TITLE
fix Issue #2418: parse_rfc3339 calling .groups() on None

### DIFF
--- a/kubernetes/base/config/dateutil.py
+++ b/kubernetes/base/config/dateutil.py
@@ -53,29 +53,37 @@ def parse_rfc3339(s):
         if not s.tzinfo:
             return s.replace(tzinfo=UTC)
         return s
-    groups = _re_rfc3339.search(s).groups()
-    dt = [0] * 7
-    for x in range(6):
-        dt[x] = int(groups[x])
-    us = 0
-    if groups[6] is not None:
-        partial_sec = float(groups[6].replace(",", "."))
-        us = int(MICROSEC_PER_SEC * partial_sec)
-    tz = UTC
-    if groups[7] is not None and groups[7] != 'Z' and groups[7] != 'z':
-        tz_groups = _re_timezone.search(groups[7]).groups()
-        hour = int(tz_groups[1])
-        minute = 0
-        if tz_groups[0] == "-":
-            hour *= -1
-        if tz_groups[2]:
-            minute = int(tz_groups[2])
-        tz = TimezoneInfo(hour, minute)
-    return datetime.datetime(
-        year=dt[0], month=dt[1], day=dt[2],
-        hour=dt[3], minute=dt[4], second=dt[5],
-        microsecond=us, tzinfo=tz)
 
+    match = _re_rfc3339.search(s)
+
+    if match is None:
+        raise ValueError(f"Error in RFC339 Date Formatting {s}")
+    try:
+        groups = match.groups()
+
+        dt = [0] * 7
+        for x in range(6):
+            dt[x] = int(groups[x])
+        us = 0
+        if groups[6] is not None:
+            partial_sec = float(groups[6].replace(",", "."))
+            us = int(MICROSEC_PER_SEC * partial_sec)
+        tz = UTC
+        if groups[7] is not None and groups[7] != 'Z' and groups[7] != 'z':
+            tz_groups = _re_timezone.search(groups[7]).groups()
+            hour = int(tz_groups[1])
+            minute = 0
+            if tz_groups[0] == "-":
+                hour *= -1
+            if tz_groups[2]:
+                minute = int(tz_groups[2])
+            tz = TimezoneInfo(hour, minute)
+        return datetime.datetime(
+            year=dt[0], month=dt[1], day=dt[2],
+            hour=dt[3], minute=dt[4], second=dt[5],
+            microsecond=us, tzinfo=tz)
+    except Exception:
+        raise ValueError(f"Error in RFC339 Date Formatting {s}")
 
 def format_rfc3339(date_time):
     if date_time.tzinfo is None:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes a runtime bug in `parse_rfc3339()` where the function would call `.groups()` on a `None` result if the regex did not match. Previously caused AttributeError: 'NoneType' object has no attribute 'groups'

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2418 

#### Special notes for your reviewer:
Includes unit test `test_2_parse_rfc3339` with malformed datetime strings to verify fix and prevent regressions.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improved RFC3339 datetime parsing logic in kube config loading. Invalid strings now raise a descriptive 
ValueError instead of a raw AttributeError.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NA
```
