### PR TITLE
#2429 Handle JSONDecodeError in dynamic client discovery

### DIFF
--- a/kubernetes/base/dynamic/discovery.py
+++ b/kubernetes/base/dynamic/discovery.py
@@ -22,6 +22,7 @@ from functools import partial
 from collections import defaultdict
 from abc import abstractmethod, abstractproperty
 
+from json.decoder import JSONDecodeError
 from urllib3.exceptions import ProtocolError, MaxRetryError
 
 from kubernetes import __version__
@@ -164,7 +165,8 @@ class Discoverer(object):
         path = '/'.join(filter(None, [prefix, group, version]))
         try:
             resources_response = self.client.request('GET', path).resources or []
-        except ServiceUnavailableError:
+        except (ServiceUnavailableError, JSONDecodeError):
+            # Handle both service unavailable errors and JSON decode errors
             resources_response = []
 
         resources_raw = list(filter(lambda resource: '/' not in resource['name'], resources_response))


### PR DESCRIPTION
#2429

When the Kubernetes API server returns a 503 Service Unavailable error with a text/plain content type (instead of application/json), the dynamic client fails with an unhandled JSONDecodeError exception while trying to parse the response as JSON.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
#### What this PR does / why we need it:

When the Kubernetes API server returns a 503 Service Unavailable error with a text/plain content type (instead of application/json), the dynamic client fails with an unhandled JSONDecodeError exception while trying to parse the response as JSON.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2429

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note NONE

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
