### PR TITLE
Try to recreate cached file if tmp file is not exist

### DIFF
--- a/kubernetes/base/config/kube_config.py
+++ b/kubernetes/base/config/kube_config.py
@@ -60,13 +60,13 @@ def _cleanup_temp_files():
     _temp_files = {}
 
 
-def _create_temp_file_with_content(content, temp_file_path=None):
+def _create_temp_file_with_content(content, temp_file_path=None, force_recreate=False):
     if len(_temp_files) == 0:
         atexit.register(_cleanup_temp_files)
     # Because we may change context several times, try to remember files we
     # created and reuse them at a small memory cost.
     content_key = str(content)
-    if content_key in _temp_files:
+    if not force_recreate and content_key in _temp_files:
         return _temp_files[content_key]
     if temp_file_path and not os.path.isdir(temp_file_path):
         os.makedirs(name=temp_file_path)
@@ -115,16 +115,10 @@ class FileOrData(object):
         decoded obj[%data_key_name] content otherwise obj[%file_key_name]."""
         use_data_if_no_file = not self._file and self._data
         if use_data_if_no_file:
-            if self._base64_file_content:
-                if isinstance(self._data, str):
-                    content = self._data.encode()
-                else:
-                    content = self._data
-                self._file = _create_temp_file_with_content(
-                    base64.standard_b64decode(content), self._temp_file_path)
-            else:
-                self._file = _create_temp_file_with_content(
-                    self._data, self._temp_file_path)
+            self._write_file()
+
+            if self._file and not os.path.isfile(self._file):
+                self._write_file(force_rewrite=True)
         if self._file and not os.path.isfile(self._file):
             raise ConfigException("File does not exist: %s" % self._file)
         return self._file
@@ -141,6 +135,18 @@ class FileOrData(object):
                 else:
                     self._data = f.read()
         return self._data
+
+    def _write_file(self, force_rewrite=False):
+        if self._base64_file_content:
+            if isinstance(self._data, str):
+                content = self._data.encode()
+            else:
+                content = self._data
+            self._file = _create_temp_file_with_content(
+                base64.standard_b64decode(content), self._temp_file_path, force_recreate=force_rewrite)
+        else:
+            self._file = _create_temp_file_with_content(
+                self._data, self._temp_file_path, force_recreate=force_rewrite)
 
 
 class CommandTokenSource(object):


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes an issue where the Kubernetes cluster configuration could not be loaded because the system deleted the temporary file. The issue occurred when working with the Kubernetes cluster in long-running applications (e.g., Celery).

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
