### PR TITLE
Update kube_config.py

### DIFF
--- a/kubernetes/base/config/kube_config.py
+++ b/kubernetes/base/config/kube_config.py
@@ -510,14 +510,19 @@ class KubeConfigLoader(object):
                     base64_file_content=False,
                     temp_file_path=self._temp_file_path).as_file()
             else:
-                logging.error('exec: missing token or clientCertificateData '
-                              'field in plugin output')
-                return None
+                logging.error("exec: missing token or clientCertificateData "
+                                 " field in plugin output")
+                 return None
+
             if 'expirationTimestamp' in status:
-                self.expiry = parse_rfc3339(status['expirationTimestamp'])
+                 try:
+                    self.expiry = parse_rfc3339(status['expirationTimestamp'])
+                 except Exception as e:
+                    logging.error("Failed to parse expirationTimestamp '%s': %s",
+                                    status['expirationTimestamp'], str(e) )
+                      raise  
             return True
-        except Exception as e:
-            logging.error(str(e))
+
 
     def _load_user_token(self):
         base_path = self._get_base_path(self._user.path)


### PR DESCRIPTION
This issue occurs because parse_rfc3339 in the Kubernetes Python client does not guard against re.search() returning None. When the input string is not a valid RFC3339 timestamp, calling .groups() on None raises an AttributeError, which in kube_config.py is logged only as 'NoneType' object has no attribute 'groups' without showing the problematic string. This makes debugging difficult and allows execution to continue with an invalid expiry value. The fix is to update parse_rfc3339 to raise a clear ValueError when parsing fails and to improve logging in kube_config.py so the invalid string is included in the error message. This will provide clearer errors, prevent silent misconfigurations, and make the client more robust.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
