### PR TITLE
Fix no_proxy reset in configuration.py

### DIFF
--- a/kubernetes/client/configuration.py
+++ b/kubernetes/client/configuration.py
@@ -159,17 +159,17 @@ class Configuration(object):
         """
 
         self.proxy = None
+        """Proxy URL
+        """
+        self.no_proxy = None
 # Load proxy from environment variables (if set)
         if os.getenv("HTTPS_PROXY"): self.proxy = os.getenv("HTTPS_PROXY")
         if os.getenv("https_proxy"): self.proxy = os.getenv("https_proxy")
         if os.getenv("HTTP_PROXY"): self.proxy = os.getenv("HTTP_PROXY")
         if os.getenv("http_proxy"): self.proxy = os.getenv("http_proxy")
-        self.no_proxy = None
         # Load no_proxy from environment variables (if set)
         if os.getenv("NO_PROXY"): self.no_proxy = os.getenv("NO_PROXY")
         if os.getenv("no_proxy"): self.no_proxy = os.getenv("no_proxy")
-        """Proxy URL
-        """
         """bypass proxy for host in the no_proxy list.
         """
         self.proxy_headers = None


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently, `self.no_proxy` is explicitly reset to `None` after being populated from environment variables (`NO_PROXY` or `no_proxy`). This effectively discards the loaded values and prevents `no_proxy` from being respected when configuring the client.

This commit removes the redundant assignment to `None`, ensuring that the `no_proxy` environment variable is preserved and proxy bypass settings are applied as expected.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No issue has been opened yet. Let me know if needed.
Fixes #

#### Special notes for your reviewer:
- The change is small but corrects behavior that currently nullifies no_proxy support.
- Please confirm whether a regression test should be added for this.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
