### PR TITLE
feat: Remove the urllib3 pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pyyaml>=5.4.1  # MIT
 websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.* # LGPLv2+
 requests # Apache-2.0
 requests-oauthlib # ISC
-urllib3>=1.24.2,<2.4.0  # MIT
+urllib3>=1.24.2 # MIT
 durationpy>=0.7 # MIT


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind regression

#### What this PR does / why we need it:

##### Pull Request Description

The PR removes the version pinning for the urllib3 library.

###### Background  
Starting with `urllib3` version `2.4.0`, stricter certificate validity checks were introduced when running on Python 3.13+ ([urllib3#3571](https://github.com/urllib3/urllib3/pull/3571)).  
This change can trigger errors such as:

```
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier
```

These errors occur only in environments where **Kubernetes clusters are configured with invalid or incomplete certificates**, most notably on **AWS EKS clusters created with Kubernetes v1.16 and earlier**.

##### Change  
We are **not pinning** the `urllib3` version. Instead, we keep the dependency flexible (optionally with a temporary upper bound if strictly necessary), ensuring compatibility with future versions of `urllib3`.

##### Rationale / Why not pin the version

- 📦 **Avoid unnecessary technical debt**  
  Pinning a widely used core dependency like `urllib3` can quickly lead to upgrade blockers and complicate maintenance down the line.

- 🔐 **Don’t block important security updates**  
  `urllib3` is a critical dependency for HTTPS communication. Pinning could delay or prevent applying security patches or other improvements.

- 🧹 **The issue only affects outdated infrastructure**  
  The certificate verification error occurs exclusively on clusters with invalid or outdated certificates. These environments should be updated rather than forcing the dependency to remain outdated.

- 🧭 **Fixing the root cause is better than downstream workarounds**  
  It’s more sustainable to address the infrastructure issue (fixing or rotating cluster certificates) than holding back modern library versions.

- ⚡ **Keeps upgrade paths open**  
  By not pinning the version, we can easily adopt future `urllib3` releases without major dependency refactors.

##### Recommendation for affected users  
If this error occurs, the correct fix is to update or properly configure the Kubernetes cluster certificates. A temporary upper bound may be set in local deployments if an immediate infrastructure fix is not feasible.

---

✅ **Summary:**  
Instead of pinning `urllib3` to a specific version, we keep the dependency flexible and address the underlying infrastructure issue.  
This approach is **more secure**, **easier to maintain**, and **aligned with dependency management best practices**.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
We no longer pin the `urllib3` version.  
`urllib3` 2.4.0 introduced stricter certificate checks on Python 3.13+, which may trigger: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier

This only affects clusters (version <=1.16) with outdated or misconfigured certificates (e.g. old AWS EKS versions). Please update the Kubernetes cluster certificates.
```