### PR TITLE
Fix: handle invalid RFC3339 expirationTimestamp in exec plugin output

### DIFF
--- a/kubernetes/base/config/kube_config.py
+++ b/kubernetes/base/config/kube_config.py
@@ -530,11 +530,16 @@ class KubeConfigLoader(object):
                 logging.error('exec: missing token or clientCertificateData '
                               'field in plugin output')
                 return None
-            if 'expirationTimestamp' in status:
-                self.expiry = parse_rfc3339(status['expirationTimestamp'])
+            if 'expirationTimestamp' in status: 
+                try:
+                    self.expiry = parse_rfc3339(status['expirationTimestamp'])
+                except ValueError as e:
+                    logging.error(f"Failed to parse expirationTimestamp: {status['expirationTimestamp']!r}, error: {e}")
+                    self.expiry = None
             return True
         except Exception as e:
             logging.error(str(e))
+                
 
     def _load_user_token(self):
         base_path = self._get_base_path(self._user.path)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR fixes a crash in `_load_from_exec_plugin()` where
`parse_rfc3339()` fails if the exec plugin returns an invalid
`expirationTimestamp`.

Changes:
- Wrap `parse_rfc3339` in a try-except block
- Log a clear error message if parsing fails
- Set `self.expiry = None` instead of crashing

#### Which issue(s) this PR fixes:
Prevents Airflow KubernetesPodOperator from crashing with 
"'NoneType' object has no attribute 'groups'" error.

Fixes #

#### Special notes for your reviewer:
No user-facing changes. Only improves error handling.

#### Does this PR introduce a user-facing change?
No

```release-note
NONE
```
