### PR TITLE
examples: add README and improve error handling in apply_from_dict

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,3 +15,15 @@ installed following the directions
 
 If you find a problem please file an
 [issue](https://github.com/kubernetes-client/python/issues).
+
+
+---
+
+## Running Examples Locally
+
+### Prerequisites
+
+- Python 3.8 or newer
+- Kubernetes Python client installed:
+  ```bash
+  pip install kubernetes

--- a/examples/apply_from_dict.py
+++ b/examples/apply_from_dict.py
@@ -1,3 +1,7 @@
+import sys
+from kubernetes.client.rest import ApiException
+
+
 from kubernetes import client, config, utils
 def main():
     config.load_kube_config()
@@ -6,5 +10,12 @@ def main():
     example_dict = {'apiVersion': 'apps/v1', 'kind': 'Deployment', 'metadata': {'name': 'k8s-py-client-nginx'}, 'spec': {'selector': {'matchLabels': {'app': 'nginx'}}, 'replicas': 1, 'template': {'metadata': {'labels': {'app': 'nginx'}}, 'spec': {'containers': [{'name': 'nginx', 'image': 'nginx:1.14.2', 'ports': [{'containerPort': 80}]}]}}}}
     utils.create_from_dict(k8s_client, example_dict)
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    try:
+        main()
+    except ApiException as e:
+        print(f"Kubernetes API error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        sys.exit(2)


### PR DESCRIPTION
### What this PR does

- Adds `examples/README.md` with QuickStart instructions for running examples.
- Improves `examples/apply_from_dict.py` by adding graceful error handling and
  a standard `__main__` entry point.

### Why this change

Examples are often the first interaction users have with the Python client.
These changes improve clarity and usability without touching generated code
or changing behavior.

### Notes

- No generated files were modified.
- No API behavior changes.
```release-note
NONE
```

