### PR TITLE
remove recommonmark from test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,6 @@ pytest-cov
 pluggy>=0.3.1
 randomize>=0.13
 sphinx>=1.4 # BSD
-recommonmark
 sphinx_markdown_tables
 pycodestyle
 autopep8


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

https://github.com/readthedocs/recommonmark project is marked as deprecated and is archived as of March 25, 2022.

There's no use of  `recommonmark` module in the existing tests. 