### PR TITLE
Apply proxy config after hotfixes

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -207,14 +207,14 @@ git diff-index --quiet --cached HEAD || git commit -am "update changelog"
 
 # Re-generate the client
 scripts/update-client.sh
-#edit comfiguration.py files
-scripts/insert_proxy_config.sh
 # Apply hotfixes
 rm -r kubernetes/test/
 git add .
 git commit -m "temporary generated commit"
 scripts/apply-hotfixes.sh
 git reset HEAD~2
+# Apply proxy config after hotfixes
+scripts/insert_proxy_config.sh
 
 # Custom object API is hosted in gen repo. Commit custom object API change
 # separately for easier review


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Currently the `no_proxy` configuration is reset after it is configured due to a duplicate `self.no_proxy = None` line being added in the autogenerated file [configuration.py](https://github.com/kubernetes-client/python/blob/master/kubernetes/client/configuration.py#L173)

Initially the thought was the script [insert_proxy_config.sh](https://github.com/kubernetes-client/python/blob/master/scripts/insert_proxy_config.sh) was applying this duplicate. However, when this script is run on the openapi generated code, `configuration.py` looks correct.

Looking at the full [release.sh](https://github.com/kubernetes-client/python/blob/master/scripts/release.sh#L211) script, there is another script applying proxy settings by cherry-picking commit https://github.com/kubernetes-client/python/commit/95a893cd1c34de11a4e3893dd1dfde4a0ca30bdc in [apply-hotfixes.sh](https://github.com/kubernetes-client/python/blob/master/scripts/apply-hotfixes.sh#L70).  This commit adds `self.no_proxy = None`.  When applied after `insert_proxy_config.sh` this results in the duplicate lines and the no_proxy becoming None.

Changing the order of the applied scripts in `release.sh` so that `insert_proxy_config.sh` is run **after** `apply-hotfixes.sh` resolves the problem because `insert_proxy_config.sh` is able to detect the existing `self.no_proxy = None` and insert it's code correctly without resetting the no_proxy.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2460 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
