### PR TITLE
Fix: properly load and parse NO_PROXY environment variable

### DIFF
--- a/kubernetes/client/configuration.py
+++ b/kubernetes/client/configuration.py
@@ -161,15 +161,28 @@ class Configuration(object):
         self.proxy = None
         """Proxy URL
         """
-        self.no_proxy = None
-# Load proxy from environment variables (if set)
+
+        self.no_proxy = []
+        # Load proxy from environment variables (if set)
         if os.getenv("HTTPS_PROXY"): self.proxy = os.getenv("HTTPS_PROXY")
         if os.getenv("https_proxy"): self.proxy = os.getenv("https_proxy")
         if os.getenv("HTTP_PROXY"): self.proxy = os.getenv("HTTP_PROXY")
         if os.getenv("http_proxy"): self.proxy = os.getenv("http_proxy")
-        # Load no_proxy from environment variables (if set)
-        if os.getenv("NO_PROXY"): self.no_proxy = os.getenv("NO_PROXY")
-        if os.getenv("no_proxy"): self.no_proxy = os.getenv("no_proxy")
+        # Load and parse no_proxy from environment variables
+        # Check for uppercase NO_PROXY first (should take precedence)
+        no_proxy_env = None
+        # Check if NO_PROXY exists in environment (even if empty)
+        if "NO_PROXY" in os.environ:
+            no_proxy_env = os.getenv("NO_PROXY")
+        elif "no_proxy" in os.environ:
+            no_proxy_env = os.getenv("no_proxy")
+            
+        if no_proxy_env is not None and no_proxy_env != "":
+            self.no_proxy = [
+                domain.strip()
+                for domain in no_proxy_env.split(",")
+                if domain.strip()
+            ]
         """bypass proxy for host in the no_proxy list.
         """
         self.proxy_headers = None


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes the handling of the `NO_PROXY` environment variable in the `Configuration` class. Previously:

1. **No parsing**: The value was stored as a raw string instead of being parsed into a list of domains
2. **Precedence issues**: When both `NO_PROXY` and `no_proxy` were set, the lowercase version could take precedence incorrectly
3. **Empty string handling**: An empty `NO_PROXY=""` was treated the same as if the variable wasn't set
4. **Default value**: `self.no_proxy` defaulted to `None` instead of an empty list

These issues caused proxy bypass settings to be ignored, breaking functionality for users relying on `no_proxy` configurations.

#### Which issue(s) this PR fixes:

Fixes #2520

#### Special notes for your reviewer:

The fix implements proper precedence checking using `in os.environ` rather than `os.getenv()` to correctly detect when a variable exists even if it's empty. The value is now parsed into a list of domains with whitespace stripped.

Test cases added cover:
- Uppercase `NO_PROXY`
- Lowercase `no_proxy`
- Both uppercase and lowercase (precedence test)
- Empty string values
- No environment variable set
- Spaces in comma-separated values

#### Does this PR introduce a user-facing change?

```release-note
Fixed: The NO_PROXY environment variable is now properly parsed into a list of domains. Uppercase NO_PROXY correctly takes precedence over lowercase no_proxy. Empty NO_PROXY="" now results in an empty list rather than falling back to the lowercase variant.

```
