### PR TITLE
Add health check to `watch.stream` for silent connection drops

### DIFF
--- a/kubernetes/base/watch/watch.py
+++ b/kubernetes/base/watch/watch.py
@@ -264,7 +264,7 @@ class Watch(object):
                 if should_retry:
                     # Add a small sleep to avoid a tight reconnect loop
                     # in case the endpoint is hard-down or errors immediately.
-                    time.sleep(min(1.0,health_check_interval))
+                    time.sleep(min(1.0, health_check_interval))
                 else:
                     raise
             finally:

--- a/kubernetes/base/watch/watch.py
+++ b/kubernetes/base/watch/watch.py
@@ -15,6 +15,9 @@
 import json
 import pydoc
 import sys
+import time
+
+from urllib3.exceptions import ProtocolError, ReadTimeoutError
 
 from kubernetes import client
 
@@ -154,6 +157,14 @@ class Watch(object):
         :param func: The API function pointer. Any parameter to the function
                      can be passed after this parameter.
 
+        :param int _health_check_interval: Optional. Number of seconds to wait
+            for data before assuming the connection has been silently dropped
+            (e.g., during a control plane upgrade). When set to a value > 0,
+            the watch will automatically detect silent connection drops and
+            reconnect using the last known resource_version. Default is 0
+            (disabled). This is useful for long-running watches that need to
+            survive cluster upgrades.
+
         :return: Event object with these keys:
                    'type': The type of event such as "ADDED", "DELETED", etc.
                    'raw_object': a dict representing the watched object.
@@ -172,6 +183,11 @@ class Watch(object):
                 ...
                 if should_stop:
                     watch.stop()
+
+        Example with health check (survives control plane upgrades):
+            for e in watch.stream(v1.list_namespace, _health_check_interval=30):
+                # If no data received for 30s, watch reconnects automatically
+                print(e['type'], e['object'].metadata.name)
         """
 
         self._stop = False
@@ -187,6 +203,20 @@ class Watch(object):
         disable_retries = ('timeout_seconds' in kwargs)
         retry_after_410 = False
         deserialize = kwargs.pop('deserialize', True)
+
+        # Health check interval: when > 0, sets a read timeout on the
+        # HTTP connection so that silent connection drops (e.g., during
+        # control plane upgrades) are detected and the watch reconnects.
+        # A value of 0 (default) disables this feature.
+        health_check_interval = kwargs.pop('_health_check_interval', 0)
+
+        # If health check is enabled and user hasn't set an explicit
+        # request timeout, use the health check interval as the read
+        # timeout. This causes urllib3 to raise ReadTimeoutError if no
+        # data arrives within the interval, which we catch below.
+        if health_check_interval > 0 and '_request_timeout' not in kwargs:
+            kwargs['_request_timeout'] = (None, health_check_interval)
+
         while True:
             resp = func(*args, **kwargs)
             try:
@@ -217,12 +247,26 @@ class Watch(object):
                             retry_after_410 = False
                             yield event
                     else:
-                        if line:  
+                        if line:
                             yield line  # Normal non-empty line
-                        else:  
-                            yield ''  # Only yield one empty line  
+                        else:
+                            yield ''  # Only yield one empty line
                     if self._stop:
                         break
+            except (ReadTimeoutError, ProtocolError) as e:
+                # Only treat a read timeout / protocol error as a silent connection drop
+                should_retry = (
+                    health_check_interval > 0
+                    and not disable_retries
+                    and watch_arg == "watch"
+                    and self.resource_version is not None
+                )
+                if should_retry:
+                    # Add a small sleep to avoid a tight reconnect loop
+                    # in case the endpoint is hard-down or errors immediately.
+                    time.sleep(min(1.0,health_check_interval))
+                else:
+                    raise
             finally:
                 resp.close()
                 resp.release_conn()

--- a/kubernetes/base/watch/watch_test.py
+++ b/kubernetes/base/watch/watch_test.py
@@ -17,6 +17,8 @@ import time
 import unittest
 from unittest.mock import Mock, call
 
+from urllib3.exceptions import ReadTimeoutError
+
 from kubernetes import client, config
 from kubernetes.client import ApiException
 
@@ -625,6 +627,202 @@ class WatchTests(unittest.TestCase):
 #            call(_preload_content=False, watch=True)
 #        ])
     
+
+    def test_health_check_detects_silent_drop_and_reconnects(self):
+        """Test that _health_check_interval detects a silent connection drop
+        (simulated by ReadTimeoutError) and reconnects automatically,
+        continuing to yield events from the new connection."""
+
+        # First response: yields one event, then raises ReadTimeoutError
+        # (simulating a silent connection drop during control plane upgrade)
+        fake_resp_1 = Mock()
+        fake_resp_1.close = Mock()
+        fake_resp_1.release_conn = Mock()
+
+        def stream_then_timeout(*args, **kwargs):
+            yield '{"type": "ADDED", "object": {"metadata": {"name": "test1", "resourceVersion": "1"}}}\n'
+            raise ReadTimeoutError(pool=None, url=None, message="Read timed out")
+
+        fake_resp_1.stream = Mock(side_effect=stream_then_timeout)
+
+        # Second response: yields another event (after reconnect)
+        fake_resp_2 = Mock()
+        fake_resp_2.close = Mock()
+        fake_resp_2.release_conn = Mock()
+        fake_resp_2.stream = Mock(
+            return_value=[
+                '{"type": "ADDED", "object": {"metadata": {"name": "test2", "resourceVersion": "2"}}}\n'
+            ])
+
+        fake_api = Mock()
+        # First call returns the stream that will timeout,
+        # second call returns the stream with new events
+        fake_api.get_namespaces = Mock(side_effect=[fake_resp_1, fake_resp_2])
+        fake_api.get_namespaces.__doc__ = ':return: V1NamespaceList'
+
+        w = Watch()
+        events = []
+        # Note: we do NOT pass timeout_seconds here because that disables
+        # retries. The watch should reconnect after the ReadTimeoutError
+        # and then stop naturally when the second stream ends (resource_version
+        # is set from the first event, so the finally block won't set _stop).
+        for e in w.stream(fake_api.get_namespaces,
+                          _health_check_interval=5):
+            events.append(e)
+            # Stop after collecting events from both connections
+            if len(events) == 2:
+                w.stop()
+
+        # Should have received events from both connections
+        self.assertEqual(2, len(events))
+        self.assertEqual("test1", events[0]['object'].metadata.name)
+        self.assertEqual("test2", events[1]['object'].metadata.name)
+
+        # Verify the API was called twice (initial + reconnect)
+        self.assertEqual(2, fake_api.get_namespaces.call_count)
+
+        # Verify both responses were properly closed
+        fake_resp_1.close.assert_called_once()
+        fake_resp_1.release_conn.assert_called_once()
+        fake_resp_2.close.assert_called_once()
+        fake_resp_2.release_conn.assert_called_once()
+
+    def test_health_check_disabled_by_default(self):
+        """Test that without _health_check_interval, a ReadTimeoutError
+        propagates to the caller (backward compatibility)."""
+
+        fake_resp = Mock()
+        fake_resp.close = Mock()
+        fake_resp.release_conn = Mock()
+
+        def stream_then_timeout(*args, **kwargs):
+            yield '{"type": "ADDED", "object": {"metadata": {"name": "test1", "resourceVersion": "1"}}}\n'
+            raise ReadTimeoutError(pool=None, url=None, message="Read timed out")
+
+        fake_resp.stream = Mock(side_effect=stream_then_timeout)
+
+        fake_api = Mock()
+        fake_api.get_namespaces = Mock(return_value=fake_resp)
+        fake_api.get_namespaces.__doc__ = ':return: V1NamespaceList'
+
+        w = Watch()
+        events = []
+        with self.assertRaises(ReadTimeoutError):
+            for e in w.stream(fake_api.get_namespaces):
+                events.append(e)
+
+        # Should have received the one event before the timeout
+        self.assertEqual(1, len(events))
+        self.assertEqual("test1", events[0]['object'].metadata.name)
+
+        # Verify the response was properly closed even after exception
+        fake_resp.close.assert_called_once()
+        fake_resp.release_conn.assert_called_once()
+
+    def test_health_check_sets_request_timeout(self):
+        """Test that _health_check_interval sets _request_timeout on the
+        API call when no explicit _request_timeout is provided."""
+
+        fake_resp = Mock()
+        fake_resp.close = Mock()
+        fake_resp.release_conn = Mock()
+        fake_resp.stream = Mock(
+            return_value=[
+                '{"type": "ADDED", "object": {"metadata": {"name": "test1", "resourceVersion": "1"}}}\n'
+            ])
+
+        fake_api = Mock()
+        fake_api.get_namespaces = Mock(return_value=fake_resp)
+        fake_api.get_namespaces.__doc__ = ':return: V1NamespaceList'
+
+        w = Watch()
+        for e in w.stream(fake_api.get_namespaces,
+                          _health_check_interval=30,
+                          timeout_seconds=10):
+            pass
+
+        # Verify _request_timeout was set to the health check interval
+        fake_api.get_namespaces.assert_called_once_with(
+            _preload_content=False, watch=True,
+            timeout_seconds=10, _request_timeout=(None,30))
+
+    def test_health_check_preserves_explicit_request_timeout(self):
+        """Test that _health_check_interval does NOT override an explicit
+        _request_timeout provided by the user."""
+
+        fake_resp = Mock()
+        fake_resp.close = Mock()
+        fake_resp.release_conn = Mock()
+        fake_resp.stream = Mock(
+            return_value=[
+                '{"type": "ADDED", "object": {"metadata": {"name": "test1", "resourceVersion": "1"}}}\n'
+            ])
+
+        fake_api = Mock()
+        fake_api.get_namespaces = Mock(return_value=fake_resp)
+        fake_api.get_namespaces.__doc__ = ':return: V1NamespaceList'
+
+        w = Watch()
+        for e in w.stream(fake_api.get_namespaces,
+                          _health_check_interval=30,
+                          _request_timeout=60,
+                          timeout_seconds=10):
+            pass
+
+        # Verify the user's _request_timeout (60) was preserved, not overridden
+        fake_api.get_namespaces.assert_called_once_with(
+            _preload_content=False, watch=True,
+            timeout_seconds=10, _request_timeout=60)
+
+    def test_health_check_reconnects_with_resource_version(self):
+        """Test that after a silent drop, the reconnect uses the last known
+        resource_version so no events are missed."""
+
+        # First response: yields events with resource versions, then times out
+        fake_resp_1 = Mock()
+        fake_resp_1.close = Mock()
+        fake_resp_1.release_conn = Mock()
+
+        def stream_then_timeout(*args, **kwargs):
+            yield '{"type": "ADDED", "object": {"metadata": {"name": "test1", "resourceVersion": "100"}}}\n'
+            yield '{"type": "MODIFIED", "object": {"metadata": {"name": "test1", "resourceVersion": "101"}}}\n'
+            raise ReadTimeoutError(pool=None, url=None, message="Read timed out")
+
+        fake_resp_1.stream = Mock(side_effect=stream_then_timeout)
+
+        # Second response: yields more events
+        fake_resp_2 = Mock()
+        fake_resp_2.close = Mock()
+        fake_resp_2.release_conn = Mock()
+        fake_resp_2.stream = Mock(
+            return_value=[
+                '{"type": "ADDED", "object": {"metadata": {"name": "test2", "resourceVersion": "102"}}}\n'
+            ])
+
+        fake_api = Mock()
+        fake_api.get_namespaces = Mock(side_effect=[fake_resp_1, fake_resp_2])
+        fake_api.get_namespaces.__doc__ = ':return: V1NamespaceList'
+
+        w = Watch()
+        events = []
+        # Note: no timeout_seconds so retries are enabled
+        for e in w.stream(fake_api.get_namespaces,
+                          _health_check_interval=5):
+            events.append(e)
+            if len(events) == 3:
+                w.stop()
+
+        self.assertEqual(3, len(events))
+
+        # Verify the second call used the last resource_version from the
+        # first connection (101) so no events are missed
+        calls = fake_api.get_namespaces.call_args_list
+        self.assertEqual(2, len(calls))
+        # First call: no resource_version
+        self.assertNotIn('resource_version', calls[0].kwargs)
+        # Second call: should have resource_version=101
+        self.assertEqual('101', calls[1].kwargs['resource_version'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/kind feature

#### What this PR does / why we need it:

When running a watch on Kubernetes objects (e.g., Jobs, Pods, Namespaces) and the Kubernetes control plane gets upgraded, the watch connection is silently dropped. The watcher hangs indefinitely - No exception is raised and no new events are received. This is because the TCP connection enters a half-open state where the client believes the connection is still alive, but the server side has been torn down during the upgrade.

This PR adds a `_health_check_interval` parameter to `watch.stream()` that detects silent connection drops and automatically reconnects:

- When `_health_check_interval` is set to a value > 0, a socket-level read timeout (`_request_timeout`) is configured on the HTTP connection
- If no data arrives within the specified interval, `urllib3` raises a `ReadTimeoutError`
- The watch catches this exception and automatically reconnects using the last known `resource_version`, ensuring no events are missed
- The feature is disabled by default (`_health_check_interval=0`), preserving full backward compatibility
- When disabled, `ReadTimeoutError` propagates to the caller as before

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2462

#### Special notes for your reviewer:

- This PR takes approach: leveraging urllib3's existing read timeout mechanism (`_request_timeout`) to break out of the blocking read, then catching the resulting `ReadTimeoutError`/`ProtocolError` exceptions
- The _ prefix on `_health_check_interval` follows the existing convention in this codebase (e.g., _preload_content, _request_timeout) for parameters that are consumed by the client library rather than passed to the API server
- 5 new unit tests added, all 24 tests (19 existing + 5 new) pass with zero regressions


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added `_health_check_interval` parameter to `watch.stream()` to detect and recover from silent connection drops during Kubernetes control plane upgrades. When set to a value > 0 (seconds), the watch will automatically reconnect if no data is received within the specified interval. Disabled by default for backward compatibility.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
