### PR TITLE
Extend Resource.watch() to accept _request_timeout

### DIFF
--- a/kubernetes/base/dynamic/client.py
+++ b/kubernetes/base/dynamic/client.py
@@ -163,7 +163,7 @@ class DynamicClient(object):
 
         return self.request('patch', path, body=body, force_conflicts=force_conflicts, **kwargs)
 
-    def watch(self, resource, namespace=None, name=None, label_selector=None, field_selector=None, resource_version=None, timeout=None, watcher=None, allow_watch_bookmarks=None):
+    def watch(self, resource, namespace=None, name=None, label_selector=None, field_selector=None, resource_version=None, timeout=None, watcher=None, allow_watch_bookmarks=None, _request_timeout=None):
         """
         Stream events for a resource from the Kubernetes API
 
@@ -177,6 +177,7 @@ class DynamicClient(object):
         :param timeout: The amount of time in seconds to wait before terminating the stream
         :param watcher: The Watcher object that will be used to stream the resource
         :param allow_watch_bookmarks: Ask the API server to send BOOKMARK events
+        :param _request_timeout: The amount of time in seconds to wait for a request to complete
 
         :return: Event object with these keys:
                    'type': The type of event such as "ADDED", "DELETED", etc.
@@ -193,6 +194,10 @@ class DynamicClient(object):
                 print(e['object'].metadata)
                 # If you want to gracefully stop the stream watcher
                 watcher.stop()
+
+            # Using a client-side request timeout
+            for e in v1_pods.watch(timeout=60, _request_timeout=(5, 65)):
+                print(e['type'])
         """
         if not watcher: watcher = watch.Watch()
 
@@ -209,6 +214,7 @@ class DynamicClient(object):
             serialize=False,
             timeout_seconds=timeout,
             allow_watch_bookmarks=allow_watch_bookmarks,
+            _request_timeout=_request_timeout,
         ):
             event['object'] = ResourceInstance(resource, event['object'])
             yield event


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
This PR extends the dynamic client's `Resource.watch()` method to accept an optional `_request_timeout` parameter. 

Previously, there was no way to configure a client-side request timeout (e.g., for connection or read timeouts) when using the dynamic client's high-level `watch()` API. Users were forced to bypass `Resource.watch()` and directly use `Watch().stream()` to achieve this. By exposing this parameter in `DynamicClient.watch()`, we provide consistent API ergonomics and eliminate the need for users to duplicate internal logic.

The `_request_timeout` parameter is now passed through to the underlying `Watch().stream()` call and handled by the base `ApiClient`.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes-client/python/issues/2533

#### Special notes for your reviewer:
The change is localized to `kubernetes/base/dynamic/client.py`. Since `Resource`, `Subresource`, and `ResourceList` all proxy their method calls to the `DynamicClient`, this update automatically enables the parameter for all dynamic resource types.

#### Does this PR introduce a user-facing change?
```release-note
Added `_request_timeout` parameter to the dynamic client's `watch()` method to allow configuration of client-side request timeouts.


Example usage:
api.watch(
    timeout=server_timeout_seconds,
    _request_timeout=(connect_timeout, read_timeout),
)