### PR TITLE
fix: handle empty error channel in returncode to prevent race condition

### DIFF
--- a/kubernetes/base/stream/ws_client.py
+++ b/kubernetes/base/stream/ws_client.py
@@ -284,12 +284,15 @@ class WSClient:
         else:
             if self._returncode is None:
                 err = self.read_channel(ERROR_CHANNEL)
+                if not err:
+                    return None
                 err = yaml.safe_load(err)
-                if err['status'] == "Success":
+                if err and err.get('status') == 'Success':
                     self._returncode = 0
-                else:
-                    self._returncode = int(err['details']['causes'][0]['message'])
-            return self._returncode
+                elif err and err.get('status') == 'Failure':
+                    self._returncode = int(
+                        err['details']['causes'][0]['message']
+                    )
 
     def close(self, **kwargs):
         """


### PR DESCRIPTION
/kind bug

_The returncode property reads from the error channel after the WebSocket connection closes. On fast-exiting commands there is a race condition where the error channel message has not been buffered yet and read_channel() returns an empty string. The previous code passed this directly to yaml.safe_load() and accessed err['status'] without a null check, causing it to incorrectly return 0 even when the command failed with a non-zero exit code._

Fixes #2328  **( pod_exec() yields inconsistent results #2328 )**

Reproducible by running command=['false'] in a loop 10 times - previously returned inconsistent exit codes (0 or 1 randomly).

Fixed a race condition in WSClient.returncode that caused pod exec commands with non-zero exit codes to intermittently return 0.