### PR TITLE
config: write api_key['BearerToken'] so v36+ SDK auth works

### DIFF
--- a/kubernetes/base/config/incluster_config.py
+++ b/kubernetes/base/config/incluster_config.py
@@ -88,7 +88,6 @@ class InClusterConfigLoader:
         client_configuration.host = self.host
         client_configuration.ssl_ca_cert = self.ssl_ca_cert
         if self.token is not None:
-            client_configuration.api_key['authorization'] = self.token
             client_configuration.api_key['BearerToken'] = self.token
         if not self._try_refresh_token:
             return

--- a/kubernetes/base/config/incluster_config.py
+++ b/kubernetes/base/config/incluster_config.py
@@ -89,6 +89,7 @@ class InClusterConfigLoader:
         client_configuration.ssl_ca_cert = self.ssl_ca_cert
         if self.token is not None:
             client_configuration.api_key['authorization'] = self.token
+            client_configuration.api_key['BearerToken'] = self.token
         if not self._try_refresh_token:
             return
 

--- a/kubernetes/base/config/incluster_config_test.py
+++ b/kubernetes/base/config/incluster_config_test.py
@@ -108,6 +108,23 @@ class InClusterConfigTest(unittest.TestCase):
         self.assertEqual('bearer ' + _TEST_NEW_TOKEN, loader.token)
         self.assertGreater(loader.token_expires_at, old_token_expires_at)
 
+    def test_load_incluster_sets_request_authorization_header(self):
+        from kubernetes.client import ApiClient
+        cert_filename = self._create_file_with_temp_content(_TEST_CERT)
+        loader = self.get_test_loader(cert_filename=cert_filename)
+        config = Configuration()
+        loader.load_and_set(config)
+
+        api_client = ApiClient(config)
+        headers = {}
+        api_client.update_params_for_auth(headers, [], ['BearerToken'])
+
+        self.assertIn('authorization', headers)
+        self.assertTrue(
+            headers['authorization'].lower().startswith('bearer '),
+            "Expected a Bearer authorization header, got: %r"
+            % headers['authorization'])
+
     def _should_fail_load(self, config_loader, reason):
         try:
             config_loader.load_and_set()

--- a/kubernetes/base/config/incluster_config_test.py
+++ b/kubernetes/base/config/incluster_config_test.py
@@ -91,7 +91,7 @@ class InClusterConfigTest(unittest.TestCase):
         loader.load_and_set(config)
 
         self.assertEqual('bearer ' + _TEST_TOKEN,
-                         config.get_api_key_with_prefix('authorization'))
+                         config.get_api_key_with_prefix('BearerToken'))
         self.assertEqual('bearer ' + _TEST_TOKEN, loader.token)
         self.assertIsNotNone(loader.token_expires_at)
 
@@ -100,11 +100,11 @@ class InClusterConfigTest(unittest.TestCase):
         loader._token_filename = self._create_file_with_temp_content(
             _TEST_NEW_TOKEN)
         self.assertEqual('bearer ' + _TEST_TOKEN,
-                         config.get_api_key_with_prefix('authorization'))
+                         config.get_api_key_with_prefix('BearerToken'))
 
         loader.token_expires_at = datetime.datetime.now()
         self.assertEqual('bearer ' + _TEST_NEW_TOKEN,
-                         config.get_api_key_with_prefix('authorization'))
+                         config.get_api_key_with_prefix('BearerToken'))
         self.assertEqual('bearer ' + _TEST_NEW_TOKEN, loader.token)
         self.assertGreater(loader.token_expires_at, old_token_expires_at)
 

--- a/kubernetes/base/config/kube_config.py
+++ b/kubernetes/base/config/kube_config.py
@@ -527,7 +527,6 @@ class KubeConfigLoader:
 
     def _set_config(self, client_configuration):
         if 'token' in self.__dict__:
-            client_configuration.api_key['authorization'] = self.token
             client_configuration.api_key['BearerToken'] = self.token
 
             def _refresh_api_key(client_configuration):

--- a/kubernetes/base/config/kube_config.py
+++ b/kubernetes/base/config/kube_config.py
@@ -528,6 +528,7 @@ class KubeConfigLoader:
     def _set_config(self, client_configuration):
         if 'token' in self.__dict__:
             client_configuration.api_key['authorization'] = self.token
+            client_configuration.api_key['BearerToken'] = self.token
 
             def _refresh_api_key(client_configuration):
                 if ('expiry' in self.__dict__ and _is_expired(self.expiry)):

--- a/kubernetes/base/config/kube_config_test.py
+++ b/kubernetes/base/config/kube_config_test.py
@@ -369,7 +369,6 @@ class FakeConfig:
         # Provided by the OpenAPI-generated Configuration class
         self.refresh_api_key_hook = None
         if token:
-            self.api_key['authorization'] = token
             self.api_key['BearerToken'] = token
 
         self.__dict__.update(kwargs)
@@ -906,7 +905,7 @@ class TestKubeConfigLoader(BaseTestCase):
         self.assertIsNotNone(fake_config.refresh_api_key_hook)
         self.assertEqual(TEST_HOST, fake_config.host)
         self.assertEqual(BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
-                         fake_config.api_key['authorization'])
+                         fake_config.api_key['BearerToken'])
 
     def test_load_gcp_token_no_refresh(self):
         loader = KubeConfigLoader(
@@ -1284,14 +1283,14 @@ class TestKubeConfigLoader(BaseTestCase):
             config_file=config_file, context="simple_token")
         self.assertEqual(TEST_HOST, client.configuration.host)
         self.assertEqual(BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
-                         client.configuration.api_key['authorization'])
+                         client.configuration.api_key['BearerToken'])
 
     def test_new_client_from_config_dict(self):
         client = new_client_from_config_dict(
             config_dict=self.TEST_KUBE_CONFIG, context="simple_token")
         self.assertEqual(TEST_HOST, client.configuration.host)
         self.assertEqual(BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
-                         client.configuration.api_key['authorization'])
+                         client.configuration.api_key['BearerToken'])
 
     def test_no_users_section(self):
         expected = FakeConfig(host=TEST_HOST)
@@ -1318,7 +1317,6 @@ class TestKubeConfigLoader(BaseTestCase):
             "token": token
         }
         expected = FakeConfig(host=TEST_HOST, api_key={
-                              "authorization": BEARER_TOKEN_FORMAT % token,
                               "BearerToken": BEARER_TOKEN_FORMAT % token})
         actual = FakeConfig()
         KubeConfigLoader(
@@ -1349,13 +1347,13 @@ class TestKubeConfigLoader(BaseTestCase):
             active_context="exec_cred_user").load_and_set(fake_config)
         # The kube config should use the first token returned from the
         # exec provider.
-        self.assertEqual(fake_config.api_key["authorization"],
+        self.assertEqual(fake_config.api_key["BearerToken"],
                          BEARER_TOKEN_FORMAT % expired_token)
         # Should now be populated with a method to refresh expired tokens.
         self.assertIsNotNone(fake_config.refresh_api_key_hook)
         # Refresh the token; the kube config should be updated.
         fake_config.refresh_api_key_hook(fake_config)
-        self.assertEqual(fake_config.api_key["authorization"],
+        self.assertEqual(fake_config.api_key["BearerToken"],
                          BEARER_TOKEN_FORMAT % current_token)
 
     @mock.patch('kubernetes.config.kube_config.ExecProvider.run')
@@ -1397,7 +1395,6 @@ class TestKubeConfigLoader(BaseTestCase):
         return_value = A(token, parse_rfc3339(datetime.datetime.now()))
         CommandTokenSource.token = mock.Mock(return_value=return_value)
         expected = FakeConfig(api_key={
-                              "authorization": BEARER_TOKEN_FORMAT % token,
                               "BearerToken": BEARER_TOKEN_FORMAT % token})
         actual = FakeConfig()
         KubeConfigLoader(
@@ -1411,7 +1408,6 @@ class TestKubeConfigLoader(BaseTestCase):
         return_value = A(token, parse_rfc3339(datetime.datetime.now()))
         CommandTokenSource.token = mock.Mock(return_value=return_value)
         expected = FakeConfig(api_key={
-                              "authorization": BEARER_TOKEN_FORMAT % token,
                               "BearerToken": BEARER_TOKEN_FORMAT % token})
         actual = FakeConfig()
         self.expect_exception(lambda: KubeConfigLoader(
@@ -1426,7 +1422,6 @@ class TestKubeConfigLoader(BaseTestCase):
         return_value = A(token, parse_rfc3339(datetime.datetime.now()))
         CommandTokenSource.token = mock.Mock(return_value=return_value)
         expected = FakeConfig(api_key={
-                              "authorization": BEARER_TOKEN_FORMAT % token,
                               "BearerToken": BEARER_TOKEN_FORMAT % token})
         actual = FakeConfig()
         self.expect_exception(lambda: KubeConfigLoader(
@@ -1728,7 +1723,7 @@ class TestKubeConfigMerger(BaseTestCase):
             config_file=kubeconfigs, context="simple_token")
         self.assertEqual(TEST_HOST, client.configuration.host)
         self.assertEqual(BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
-                         client.configuration.api_key['authorization'])
+                         client.configuration.api_key['BearerToken'])
 
     def test_merge_with_context_in_different_file(self):
         kubeconfigs = self._create_multi_config(self.TEST_KUBE_CONFIG_SET2)
@@ -1744,7 +1739,7 @@ class TestKubeConfigMerger(BaseTestCase):
         self.assertEqual(active_context, expected_contexts[0])
         self.assertEqual(TEST_HOST, client.configuration.host)
         self.assertEqual(BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
-                         client.configuration.api_key['authorization'])
+                         client.configuration.api_key['BearerToken'])
 
     def test_save_changes(self):
         kubeconfigs = self._create_multi_config(self.TEST_KUBE_CONFIG_SET1)

--- a/kubernetes/base/config/kube_config_test.py
+++ b/kubernetes/base/config/kube_config_test.py
@@ -370,6 +370,7 @@ class FakeConfig:
         self.refresh_api_key_hook = None
         if token:
             self.api_key['authorization'] = token
+            self.api_key['BearerToken'] = token
 
         self.__dict__.update(kwargs)
 
@@ -1317,7 +1318,8 @@ class TestKubeConfigLoader(BaseTestCase):
             "token": token
         }
         expected = FakeConfig(host=TEST_HOST, api_key={
-                              "authorization": BEARER_TOKEN_FORMAT % token})
+                              "authorization": BEARER_TOKEN_FORMAT % token,
+                              "BearerToken": BEARER_TOKEN_FORMAT % token})
         actual = FakeConfig()
         KubeConfigLoader(
             config_dict=self.TEST_KUBE_CONFIG,
@@ -1395,7 +1397,8 @@ class TestKubeConfigLoader(BaseTestCase):
         return_value = A(token, parse_rfc3339(datetime.datetime.now()))
         CommandTokenSource.token = mock.Mock(return_value=return_value)
         expected = FakeConfig(api_key={
-                              "authorization": BEARER_TOKEN_FORMAT % token})
+                              "authorization": BEARER_TOKEN_FORMAT % token,
+                              "BearerToken": BEARER_TOKEN_FORMAT % token})
         actual = FakeConfig()
         KubeConfigLoader(
             config_dict=self.TEST_KUBE_CONFIG,
@@ -1408,7 +1411,8 @@ class TestKubeConfigLoader(BaseTestCase):
         return_value = A(token, parse_rfc3339(datetime.datetime.now()))
         CommandTokenSource.token = mock.Mock(return_value=return_value)
         expected = FakeConfig(api_key={
-                              "authorization": BEARER_TOKEN_FORMAT % token})
+                              "authorization": BEARER_TOKEN_FORMAT % token,
+                              "BearerToken": BEARER_TOKEN_FORMAT % token})
         actual = FakeConfig()
         self.expect_exception(lambda: KubeConfigLoader(
             config_dict=self.TEST_KUBE_CONFIG,
@@ -1422,7 +1426,8 @@ class TestKubeConfigLoader(BaseTestCase):
         return_value = A(token, parse_rfc3339(datetime.datetime.now()))
         CommandTokenSource.token = mock.Mock(return_value=return_value)
         expected = FakeConfig(api_key={
-                              "authorization": BEARER_TOKEN_FORMAT % token})
+                              "authorization": BEARER_TOKEN_FORMAT % token,
+                              "BearerToken": BEARER_TOKEN_FORMAT % token})
         actual = FakeConfig()
         self.expect_exception(lambda: KubeConfigLoader(
             config_dict=self.TEST_KUBE_CONFIG,

--- a/kubernetes_asyncio/config/incluster_config.py
+++ b/kubernetes_asyncio/config/incluster_config.py
@@ -89,6 +89,7 @@ class InClusterConfigLoader(object):
         client_configuration.ssl_ca_cert = self.ssl_ca_cert
         if self.token is not None:
             client_configuration.api_key['authorization'] = self.token
+            client_configuration.api_key['BearerToken'] = self.token
         if not self._try_refresh_token:
             return
 

--- a/kubernetes_asyncio/config/incluster_config.py
+++ b/kubernetes_asyncio/config/incluster_config.py
@@ -88,7 +88,6 @@ class InClusterConfigLoader(object):
         client_configuration.host = self.host
         client_configuration.ssl_ca_cert = self.ssl_ca_cert
         if self.token is not None:
-            client_configuration.api_key['authorization'] = self.token
             client_configuration.api_key['BearerToken'] = self.token
         if not self._try_refresh_token:
             return

--- a/kubernetes_asyncio/config/incluster_config_test.py
+++ b/kubernetes_asyncio/config/incluster_config_test.py
@@ -91,7 +91,7 @@ class InClusterConfigTest(unittest.TestCase):
         loader.load_and_set(config)
 
         self.assertEqual('bearer ' + _TEST_TOKEN,
-                         await config.get_api_key_with_prefix('authorization'))
+                         await config.get_api_key_with_prefix('BearerToken'))
         self.assertEqual('bearer ' + _TEST_TOKEN, loader.token)
         self.assertIsNotNone(loader.token_expires_at)
 
@@ -100,11 +100,11 @@ class InClusterConfigTest(unittest.TestCase):
         loader._token_filename = self._create_file_with_temp_content(
             _TEST_NEW_TOKEN)
         self.assertEqual('bearer ' + _TEST_TOKEN,
-                         await config.get_api_key_with_prefix('authorization'))
+                         await config.get_api_key_with_prefix('BearerToken'))
 
         loader.token_expires_at = datetime.datetime.now()
         self.assertEqual('bearer ' + _TEST_NEW_TOKEN,
-                         await config.get_api_key_with_prefix('authorization'))
+                         await config.get_api_key_with_prefix('BearerToken'))
         self.assertEqual('bearer ' + _TEST_NEW_TOKEN, loader.token)
         self.assertGreater(loader.token_expires_at, old_token_expires_at)
 


### PR DESCRIPTION
## What this PR does

Updates the in-cluster and kubeconfig loaders in `kubernetes/base/config/`, plus `kubernetes_asyncio/config/incluster_config.py`, to write the bearer token under `api_key['BearerToken']` (the v36+ lookup key) instead of `api_key['authorization']` (the v35 lookup key). Updates the corresponding test assertions to read the new key. Adds a regression test that exercises the end-to-end flow (Configuration → ApiClient → outgoing Authorization header) which the existing tests did not cover.

## Why

v36 rewrote `Configuration.auth_settings()` to look up the bearer-token credential under `api_key['BearerToken']`, matching the OpenAPI security scheme name. This rename was declared a breaking change in the project CHANGELOG as part of the openapi-generator v6.6.0 upgrade. The hand-written loaders in `kubernetes/base/config/` and `kubernetes_asyncio/config/incluster_config.py` were not updated to follow the rename - they still write `api_key['authorization']`. (Asyncio's `kube_config.py` already writes `'BearerToken'`, so it isn't affected.)

Net effect on v36: every call to `load_incluster_config()` (and `load_kube_config()` with a static token, including the async equivalents) produces a `Configuration` whose `auth_settings()` yields no bearer credential, so outgoing API requests are sent without an `Authorization` header and the apiserver treats them as `system:anonymous`. The failure mode is silent - no warning, no exception, just 401s from every API call.

See #2582 for the user-side report and a minimal repro.

## Test plan

- Added `test_load_incluster_sets_request_authorization_header` to `kubernetes/base/config/incluster_config_test.py`. It drives a real `ApiClient.update_params_for_auth()` against a freshly-loaded `Configuration` and asserts the resulting headers contain an `Authorization` entry - the end-to-end invariant that v36 broke.
- Verified the new regression test fails on `kubernetes==36.0.0` against the unfixed loader (`AssertionError: 'authorization' not found in {}`) and passes with the fix.
- Verified all 103 sync tests in `kubernetes/base/config/` and 72 async tests in `kubernetes_asyncio/config/` pass on v36 with the change applied.

Fixes #2582

```release-note
Fix `load_incluster_config()` and `load_kube_config()` (sync and async, with a static token) so requests carry an `Authorization` header on `kubernetes-client/python` v36+. Without this fix, in-cluster pods upgrading to v36 silently send unauthenticated requests and the apiserver rejects them as `system:anonymous`.
```