### PR TITLE
Restore bearer-token fallback in Configuration.auth_settings()

### DIFF
--- a/kubernetes/aio/client/configuration.py
+++ b/kubernetes/aio/client/configuration.py
@@ -415,13 +415,19 @@ conf = client.Configuration(
         :return: The Auth Settings information dict.
         """
         auth = {}
-        if 'BearerToken' in self.api_key:
+        # Backward compatibility: prior to v36.0.0 the bearer token was
+        # stored under the 'authorization' api_key. Continue to honor it
+        # so user code that sets ``config.api_key['authorization']``
+        # directly keeps working with the new 'BearerToken' key the
+        # generated client now looks for.
+        # See: https://github.com/kubernetes-client/python/issues/2595
+        if 'BearerToken' in self.api_key or 'authorization' in self.api_key:
             auth['BearerToken'] = {
                 'type': 'api_key',
                 'in': 'header',
                 'key': 'authorization',
                 'value': await self.get_api_key_with_prefix(
-                    'BearerToken',
+                    'BearerToken', alias='authorization',
                 ),
             }
         return auth

--- a/kubernetes/client/configuration.py
+++ b/kubernetes/client/configuration.py
@@ -406,13 +406,19 @@ conf = client.Configuration(
         :return: The Auth Settings information dict.
         """
         auth = {}
-        if 'BearerToken' in self.api_key:
+        # Backward compatibility: prior to v36.0.0 the bearer token was
+        # stored under the 'authorization' api_key. Continue to honor it
+        # so user code that sets ``config.api_key['authorization']``
+        # directly keeps working with the new 'BearerToken' key the
+        # generated client now looks for.
+        # See: https://github.com/kubernetes-client/python/issues/2595
+        if 'BearerToken' in self.api_key or 'authorization' in self.api_key:
             auth['BearerToken'] = {
                 'type': 'api_key',
                 'in': 'header',
                 'key': 'authorization',
                 'value': self.get_api_key_with_prefix(
-                    'BearerToken',
+                    'BearerToken', alias='authorization',
                 ),
             }
         return auth

--- a/kubernetes/test/test_api_client.py
+++ b/kubernetes/test/test_api_client.py
@@ -78,3 +78,45 @@ class TestApiClient(unittest.TestCase):
             # test
             client = kubernetes.client.ApiClient(configuration=config)
             self.assertEqual( expected_pool, type(client.rest_client.pool_manager) )
+
+
+class TestConfigurationAuthSettings(unittest.TestCase):
+    """Regression tests for Configuration.auth_settings() bearer-token lookup.
+
+    Prior to v36.0.0 the generated client stored the bearer token under
+    ``api_key['authorization']`` (e.g. set by ``load_kube_config`` or by
+    user code directly). v36.0.0 switched the lookup to
+    ``api_key['BearerToken']`` without a fallback, which silently dropped
+    the Authorization header from every outgoing request and caused 401
+    Unauthorized against any cluster relying on bearer tokens.
+    See: https://github.com/kubernetes-client/python/issues/2595
+    """
+
+    def _bearer_value(self, config):
+        settings = config.auth_settings()
+        self.assertIn('BearerToken', settings)
+        return settings['BearerToken']['value']
+
+    def test_auth_settings_with_bearer_token_key(self):
+        """The new key 'BearerToken' continues to work."""
+        config = Configuration()
+        config.api_key['BearerToken'] = 'Bearer abc123'
+        self.assertEqual(self._bearer_value(config), 'Bearer abc123')
+
+    def test_auth_settings_with_authorization_key(self):
+        """Legacy key 'authorization' is honored as a fallback."""
+        config = Configuration()
+        config.api_key['authorization'] = 'Bearer abc123'
+        self.assertEqual(self._bearer_value(config), 'Bearer abc123')
+
+    def test_auth_settings_bearer_token_takes_precedence(self):
+        """When both keys are set, 'BearerToken' wins."""
+        config = Configuration()
+        config.api_key['BearerToken'] = 'Bearer new'
+        config.api_key['authorization'] = 'Bearer old'
+        self.assertEqual(self._bearer_value(config), 'Bearer new')
+
+    def test_auth_settings_with_no_token(self):
+        """No api_key entry yields an empty auth dict."""
+        config = Configuration()
+        self.assertEqual(config.auth_settings(), {})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips:
1. https://git.k8s.io/community/contributors/guide/first-contribution.md
2. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
-->

#### What this PR does / why we need it:

Restores backward compatibility for the bearer-token lookup in
`Configuration.auth_settings()`.

Before v36.0.0, the generated client stored the bearer token under
`api_key['authorization']`. v36.0.0 changed the lookup to
`api_key['BearerToken']` without a fallback, so any caller that still
writes the token under `'authorization'` ends up sending requests
without an `Authorization` header and gets `401 Unauthorized` from the
API server.

The user-visible symptom is "everything that used to work with my
bearer-token kubeconfig now returns 401 against the same cluster after
upgrading to v36.0.0", on both REST and WebSocket exec paths.

This PR keeps the new `'BearerToken'` key as the primary lookup but
adds `'authorization'` as a fallback alias — using the
`alias=` parameter already supported by `get_api_key_with_prefix`. No
mutation of `self.api_key`, no new branches in the hot path.

This matches @yliaog's suggestion in #2595 to carry a patch on
`Configuration.auth_settings()` for a transition period while existing
user code migrates from `'authorization'` to `'BearerToken'`.

#### Which issue(s) this PR fixes:

Fixes #2595

#### Special notes for your reviewer:

- Applied symmetrically to the sync (`kubernetes/client/configuration.py`)
  and async (`kubernetes/aio/client/configuration.py`) variants.
- New regression tests in `kubernetes/test/test_api_client.py` cover all
  four cases: `BearerToken` alone, `authorization` alone, both set
  (precedence), and neither set.
- The `kubernetes/client/` and `kubernetes/test/` trees are generated;
  once this is merged, the patch SHA can be added to
  `scripts/apply-hotfixes.sh` so it survives the next regeneration.

#### Does this PR introduce a user-facing change?
```release-note
Restored backward compatibility for `Configuration.auth_settings()`:
the legacy `api_key['authorization']` lookup is honored as a fallback
when `api_key['BearerToken']` is not set, fixing 401 Unauthorized
regressions seen after upgrading to v36.0.0 (#2595).
```