### PR TITLE
Fix pod log stream follow detection

### DIFF
--- a/kubernetes/base/watch/watch.py
+++ b/kubernetes/base/watch/watch.py
@@ -19,7 +19,7 @@ import pydoc
 from kubernetes import client
 
 PYDOC_RETURN_LABEL = ":rtype:"
-PYDOC_FOLLOW_PARAM = ":param bool follow:"
+PYDOC_FOLLOW_PARAMS = (":param bool follow:", ":param follow:")
 
 # Removing this suffix from return type name should give us event's object
 # type. e.g., if list_namespaces() returns "NamespaceList" type,
@@ -111,7 +111,8 @@ class Watch:
         return return_type
 
     def get_watch_argument_name(self, func):
-        if PYDOC_FOLLOW_PARAM in pydoc.getdoc(func):
+        doc = pydoc.getdoc(func)
+        if any(param in doc for param in PYDOC_FOLLOW_PARAMS):
             return 'follow'
         else:
             return 'watch'

--- a/kubernetes/base/watch/watch_test.py
+++ b/kubernetes/base/watch/watch_test.py
@@ -19,6 +19,7 @@ from unittest.mock import Mock, call
 
 from kubernetes import client, config
 from kubernetes.client import ApiException
+from kubernetes.client.exceptions import ApiTypeError
 
 from .watch import Watch
 
@@ -213,6 +214,44 @@ class WatchTests(unittest.TestCase):
             count += 1
             # make sure we can stop the watch and the last event with won't be
             # returned
+            if count == 2:
+                w.stop()
+
+        fake_api.read_namespaced_pod_log.assert_called_once_with(
+            _preload_content=False, follow=True)
+        fake_resp.stream.assert_called_once_with(
+            amt=None, decode_content=False)
+        fake_resp.close.assert_called_once()
+        fake_resp.release_conn.assert_called_once()
+
+    def test_watch_for_follow_with_split_param_type_docstring(self):
+        fake_resp = Mock()
+        fake_resp.close = Mock()
+        fake_resp.release_conn = Mock()
+        fake_resp.stream = Mock(
+            return_value=[
+                'log_line_1\n',
+                'log_line_2\n'])
+
+        def read_pod_log(*args, **kwargs):
+            if 'watch' in kwargs:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument 'watch'"
+                    " to method read_namespaced_pod_log")
+            return fake_resp
+
+        fake_api = Mock()
+        fake_api.read_namespaced_pod_log = Mock(side_effect=read_pod_log)
+        fake_api.read_namespaced_pod_log.__doc__ = (
+            ':param follow: Follow the log stream of the pod. Defaults to false.\n'
+            ':type follow: bool\n'
+            ':rtype: str')
+
+        w = Watch()
+        count = 1
+        for e in w.stream(fake_api.read_namespaced_pod_log):
+            self.assertEqual("log_line_1", e)
+            count += 1
             if count == 2:
                 w.stop()
 


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
/kind regression

**What this PR does / why we need it:**
Watch.stream decides whether to pass watch= or follow= by looking at the wrapped API method docstring.

The generated pod log method now documents follow as split :param follow: and :type follow: bool lines instead of the older :param bool follow: form. Because the watch code only recognized the older form, it passed watch=True to read_namespaced_pod_log, and the generated client rejected that kwarg.

This keeps the existing old-format check and also recognizes the generated split follow docstring, so pod log streaming uses follow=True while normal watch APIs continue to use watch=True.

**Which issue(s) this PR fixes:**
Fixes #2610

**Special notes for your reviewer:**
Added a regression test for the generated pod log docstring format. This is scoped to the Watch.stream argument selection path and does not change generated client files.

Checked locally with:

```
python3 -m unittest kubernetes.watch.watch_test.WatchTests.test_watch_for_follow kubernetes.watch.watch_test.WatchTests.test_watch_for_follow_with_split_param_type_docstring
python3 -m unittest kubernetes.base.watch.watch_test
python3 -m pytest -q kubernetes/base/watch/watch_test.py
python3 -m unittest discover
git diff --check
```
**Does this PR introduce a user-facing change?**
Yes - Watch.stream(v1.read_namespaced_pod_log, ...) now uses follow=True for pod log streaming with the current generated docstring format, instead of failing with an unexpected watch argument.

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
NONE