### PR TITLE
Fix Watch follow parameter detection

### DIFF
--- a/kubernetes/base/watch/watch.py
+++ b/kubernetes/base/watch/watch.py
@@ -19,7 +19,7 @@ import pydoc
 from kubernetes import client
 
 PYDOC_RETURN_LABEL = ":rtype:"
-PYDOC_FOLLOW_PARAM = ":param bool follow:"
+PYDOC_FOLLOW_PARAM = ":param follow:"
 
 # Removing this suffix from return type name should give us event's object
 # type. e.g., if list_namespaces() returns "NamespaceList" type,

--- a/kubernetes/base/watch/watch_test.py
+++ b/kubernetes/base/watch/watch_test.py
@@ -204,7 +204,8 @@ class WatchTests(unittest.TestCase):
 
         fake_api = Mock()
         fake_api.read_namespaced_pod_log = Mock(return_value=fake_resp)
-        fake_api.read_namespaced_pod_log.__doc__ = ':param bool follow:\n:rtype: str'
+        fake_api.read_namespaced_pod_log.__doc__ = (
+            ':param follow:\n:type follow: bool\n:rtype: str')
 
         w = Watch()
         count = 1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

OpenAPI-generated methods now document parameter names and types on separate
lines. `Watch` still looked for the previous combined `:param bool follow:`
form, so it sent `watch=True` to pod log methods. Those methods reject the
unexpected keyword instead of streaming logs.

Match the generated `:param follow:` form and update the existing test fixture
to use the current generated docstring shape.

#### Which issue(s) this PR fixes:

Fixes #2615

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
Fix Watch.stream selecting watch instead of follow when streaming pod logs.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```