### PR TITLE
Fix regressions in Configuration.get_api_key_with_prefix bearer-token prefix lookup

### DIFF
--- a/kubernetes/aio/client/configuration.py
+++ b/kubernetes/aio/client/configuration.py
@@ -388,7 +388,8 @@ conf = client.Configuration(
                 await result
         key = self.api_key.get(identifier, self.api_key.get(alias) if alias is not None else None)
         if key:
-            prefix = self.api_key_prefix.get(identifier)
+            prefix = self.api_key_prefix.get(
+                identifier, self.api_key_prefix.get(alias) if alias is not None else None)
             if prefix:
                 return "%s %s" % (prefix, key)
             else:

--- a/kubernetes/aio/config/incluster_config_test.py
+++ b/kubernetes/aio/config/incluster_config_test.py
@@ -17,6 +17,7 @@ import os
 import tempfile
 import time
 import unittest
+from unittest import IsolatedAsyncioTestCase
 
 from kubernetes.aio.client import Configuration
 
@@ -43,7 +44,7 @@ _TEST_IPV6_ENVIRON = {
 }
 
 
-class InClusterConfigTest(unittest.TestCase):
+class InClusterConfigTest(IsolatedAsyncioTestCase):
     def setUp(self):
         self._temp_files = []
 
@@ -107,6 +108,18 @@ class InClusterConfigTest(unittest.TestCase):
                          await config.get_api_key_with_prefix('BearerToken'))
         self.assertEqual('bearer ' + _TEST_NEW_TOKEN, loader.token)
         self.assertGreater(loader.token_expires_at, old_token_expires_at)
+
+    async def test_auth_settings_with_authorization_key_and_prefix(self):
+        """Legacy callers that split the token and prefix across
+        api_key['authorization'] and api_key_prefix['authorization'] (rather
+        than embedding "Bearer " in the token itself) must still get the
+        prefix applied. https://github.com/kubernetes-client/python/issues/2592
+        """
+        config = Configuration()
+        config.api_key['authorization'] = 'abc123'
+        config.api_key_prefix['authorization'] = 'Bearer'
+        settings = await config.auth_settings()
+        self.assertEqual(settings['BearerToken']['value'], 'Bearer abc123')
 
     def _should_fail_load(self, config_loader, reason):
         try:

--- a/kubernetes/client/configuration.py
+++ b/kubernetes/client/configuration.py
@@ -379,7 +379,8 @@ conf = client.Configuration(
             self.refresh_api_key_hook(self)
         key = self.api_key.get(identifier, self.api_key.get(alias) if alias is not None else None)
         if key:
-            prefix = self.api_key_prefix.get(identifier)
+            prefix = self.api_key_prefix.get(
+                identifier, self.api_key_prefix.get(alias) if alias is not None else None)
             if prefix:
                 return "%s %s" % (prefix, key)
             else:

--- a/kubernetes/test/test_api_client.py
+++ b/kubernetes/test/test_api_client.py
@@ -120,3 +120,14 @@ class TestConfigurationAuthSettings(unittest.TestCase):
         """No api_key entry yields an empty auth dict."""
         config = Configuration()
         self.assertEqual(config.auth_settings(), {})
+
+    def test_auth_settings_with_authorization_key_and_prefix(self):
+        """Legacy callers that split the token and prefix across
+        api_key['authorization'] and api_key_prefix['authorization'] (rather
+        than embedding "Bearer " in the token itself) must still get the
+        prefix applied. https://github.com/kubernetes-client/python/issues/2592
+        """
+        config = Configuration()
+        config.api_key['authorization'] = 'abc123'
+        config.api_key_prefix['authorization'] = 'Bearer'
+        self.assertEqual(self._bearer_value(config), 'Bearer abc123')


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

#2604 restored the `api_key['authorization']` fallback in `auth_settings()` by calling `get_api_key_with_prefix('BearerToken', alias='authorization')`, but `get_api_key_with_prefix` only applies the `alias` fallback to the `api_key` lookup, not the `api_key_prefix` lookup:

```python
key = self.api_key.get(identifier, self.api_key.get(alias) if alias is not None else None)
if key:
    prefix = self.api_key_prefix.get(identifier)  # never checks `alias`
```

So callers that set the prefix under the legacy `'authorization'` key (rather than embedding `"Bearer "` directly in the token string) get a bearer token with no `"Bearer "` prefix in the resulting `Authorization` header. Most API servers — and specifically GKE's anonymous-auth fallback — don't recognize an unprefixed token as a valid bearer credential, so the request is treated as `system:anonymous`.

This reproduces with a plain manual `Configuration()`, no `load_incluster_config()`/`load_kube_config()` involved:

```python
from kubernetes import client

configuration = client.Configuration()
configuration.api_key["authorization"] = "<token>"
configuration.api_key_prefix["authorization"] = "Bearer"

print(configuration.auth_settings())
# before this PR: value = '<token>'          (missing "Bearer " prefix)
# after this PR:  value = 'Bearer <token>'   (correct)
```

This PR applies the same alias fallback already used for the key lookup to the prefix lookup, symmetrically in the sync (`kubernetes/client/configuration.py`) and async (`kubernetes/aio/client/configuration.py`) variants.

Verified against a real cluster in production: a service using this exact pattern (manual `Configuration` with `api_key`/`api_key_prefix` under `'authorization'`, talking to an external GKE cluster) was hitting `system:anonymous` on 36.0.2. Built this fix into that service via a `git+` dependency pointing at this branch and confirmed it now authenticates correctly against the live cluster with zero code changes on the caller's side.

#### Which issue(s) this PR fixes:

Fixes #2592

- Comments in #2592 from @markafarrell and @anastasiyatolstikenableu independently confirm 36.0.2 doesn't fully fix this for callers outside `load_incluster_config()`/`load_kube_config()`, matching this root cause.
- Applied symmetrically to the sync and async variants, matching the precedent set by #2604.
- Added a regression test, `test_auth_settings_with_authorization_key_and_prefix`, covering the split key/prefix case that the existing #2604 tests didn't exercise (those set the full `'Bearer abc123'` string directly in `api_key['authorization']`, which doesn't touch the prefix lookup at all).
- I did not touch `scripts/apply-hotfixes.sh` in this PR since it needs this commit's final SHA — happy to follow up with that once this merges, same as was done for 5621a4c after #2604.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a regression where `Configuration.auth_settings()` would drop the `"Bearer "` prefix for callers using the legacy `api_key['authorization']` / `api_key_prefix['authorization']` convention, causing requests to be sent without a valid Authorization header and rejected as `system:anonymous`. This is a follow-up to the fix in #2604, which restored the key fallback but missed the prefix fallback.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```