### PR TITLE
Fix readline_channel crash and None return on default timeout

### DIFF
--- a/kubernetes/base/stream/ws_client.py
+++ b/kubernetes/base/stream/ws_client.py
@@ -128,6 +128,7 @@ class WSClient:
                 return b"" if self.binary else ""
 
             self.update(timeout=(timeout - time.time() + start))
+        return b"" if self.binary else ""
 
     def write_channel(self, channel, data):
         """Write data to a channel."""
@@ -216,11 +217,15 @@ class WSClient:
         if hasattr(select, "poll"):
             poll = select.poll()
             poll.register(self.sock.sock, select.POLLIN)
-            if timeout is not None:
+            if timeout is not None and timeout != float("inf"):
                 timeout *= 1_000  # poll method uses milliseconds as the time unit
+            else:
+                timeout = None
             r = poll.poll(timeout)
             poll.unregister(self.sock.sock)
         else:
+            if timeout == float("inf"):
+                timeout = None
             r, _, _ = select.select(
                 (self.sock.sock, ), (), (), timeout)
 

--- a/kubernetes/base/stream/ws_client_test.py
+++ b/kubernetes/base/stream/ws_client_test.py
@@ -342,6 +342,48 @@ class WSClientProtocolTest(unittest.TestCase):
                 self.assertEqual(data3, "")
                 mock_update.assert_not_called()
 
+    def test_update_infinite_timeout_polls_without_overflow(self):
+        """Verify update maps an infinite (default) timeout to a blocking poll instead of overflowing"""
+        with patch.object(ws_client_module, 'create_websocket') as mock_create, \
+             patch('select.poll') as mock_poll:
+            mock_poll.return_value.poll.return_value = []
+            mock_ws = MagicMock()
+            mock_ws.subprotocol = V5_CHANNEL_PROTOCOL
+            mock_ws.connected = True
+            mock_ws.sock.fileno.return_value = 10
+            mock_create.return_value = mock_ws
+
+            client = WSClient(self.config_mock, "ws://test", headers=None, capture_all=True)
+            client.update(timeout=float("inf"))
+
+            mock_poll.return_value.poll.assert_called_once_with(None)
+
+    def test_readline_channel_returns_empty_string_on_expired_timeout(self):
+        """Verify readline_channel returns '' (not None) when a finite timeout expires"""
+        with patch.object(ws_client_module, 'create_websocket') as mock_create:
+            mock_ws = MagicMock()
+            mock_ws.subprotocol = V5_CHANNEL_PROTOCOL
+            mock_ws.connected = True
+            mock_create.return_value = mock_ws
+
+            client = WSClient(self.config_mock, "ws://test", headers=None, capture_all=True, binary=False)
+            with patch.object(client, 'update'):
+                line = client.readline_channel(1, timeout=0.01)
+            self.assertEqual(line, "")
+
+    def test_readline_channel_returns_empty_bytes_on_expired_timeout(self):
+        """Verify readline_channel returns b'' (not None) when a finite timeout expires in binary mode"""
+        with patch.object(ws_client_module, 'create_websocket') as mock_create:
+            mock_ws = MagicMock()
+            mock_ws.subprotocol = V5_CHANNEL_PROTOCOL
+            mock_ws.connected = True
+            mock_create.return_value = mock_ws
+
+            client = WSClient(self.config_mock, "ws://test", headers=None, capture_all=True, binary=True)
+            with patch.object(client, 'update'):
+                line = client.readline_channel(1, timeout=0.01)
+            self.assertEqual(line, b"")
+
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
With the default timeout, readline_channel converted None to float("inf") and crashed in update() when it reached select.poll().poll(). An infinite timeout now maps to a blocking poll, and an expired finite timeout returns '' or b'' like the other read methods instead of None.

#### Which issue(s) this PR fixes:
Fixes #2621

#### Does this PR introduce a user-facing change?
```release-note
Fix readline_channel, readline_stdout and readline_stderr crashing with OverflowError when using the default timeout, and returning None when a timeout expires.
```