### PR TITLE
Fix OIDC token refresh failing on Windows when idp-certificate-authority-data is set

### DIFF
--- a/kubernetes/base/config/kube_config.py
+++ b/kubernetes/base/config/kube_config.py
@@ -383,16 +383,14 @@ class KubeConfigLoader:
         config = Configuration()
 
         if 'idp-certificate-authority-data' in provider['config']:
-            ca_cert = tempfile.NamedTemporaryFile(delete=True)
-
             cert = base64.b64decode(
                 provider['config']['idp-certificate-authority-data']
             ).decode('utf-8')
 
-            with open(ca_cert.name, 'w') as fh:
-                fh.write(cert)
-
-            config.ssl_ca_cert = ca_cert.name
+            # Use the shared temp-file helper instead of reopening a
+            # NamedTemporaryFile by name, which fails with PermissionError
+            # on Windows while the original handle is still open.
+            config.ssl_ca_cert = _create_temp_file_with_content(cert)
 
         elif 'idp-certificate-authority' in provider['config']:
             config.ssl_ca_cert = provider['config']['idp-certificate-authority']


### PR DESCRIPTION
**What this does**

`KubeConfigLoader._refresh_oidc` wrote the IdP CA certificate by creating a `tempfile.NamedTemporaryFile(delete=True)` and then re-opening it by name. On Windows that second open raises `PermissionError` (the file is held exclusively while open), so OIDC token refresh fails at runtime for any kubeconfig using `idp-certificate-authority-data`. This is the temp-file portion of #2427.

The fix reuses the module's existing `_create_temp_file_with_content` helper (mkstemp-based, closed before reuse, cleaned up via the existing atexit handler) — the same mechanism this file already uses for other inline certificate data, so behavior is now consistent across platforms and cleanup no longer depends on GC timing.

**Testing**

`pytest kubernetes/base/config/kube_config_test.py` on Windows 11: 75 passed — including `test_oidc_with_refresh`, which fails with `PermissionError` before this change. No test modifications were needed; the existing tests cover the path once the production code is fixed.

Ref #2427 — planned as the first of a short series of small Windows fixes discussed there.

```release-note
Fixed OIDC token refresh failing with PermissionError on Windows when the kubeconfig uses idp-certificate-authority-data.
```