### PR TITLE
docs: clarify chunked behavior in non-blocking pod log example

### DIFF
--- a/examples/pod_logs_non_blocking.py
+++ b/examples/pod_logs_non_blocking.py
@@ -26,6 +26,9 @@ def stream_logs():
     )
 
     # 👇 make socket non-blocking with timeout
+    # Note: when streaming logs with _preload_content=False, the transport may
+    # deliver arbitrary chunk boundaries, so callers should split or buffer data
+    # themselves if they need line-oriented processing.
     resp._fp.fp.raw._sock.settimeout(1)
 
     try:


### PR DESCRIPTION
## Summary

Clarify the behavior of pod log streaming when `_preload_content=False` is used.

The non-blocking log streaming example now explains that streamed data is returned in transport-level chunks, which may contain multiple or partial log lines. Applications that require line-oriented processing should buffer and split on newline boundaries.

## Motivation

This change improves the example by documenting behavior that can surprise users when streaming logs with `_preload_content=False`, as discussed in Issue #2426.

## Changes

- Added explanatory comments to `examples/pod_logs_non_blocking.py`
- No runtime behavior changed