### PR TITLE
Fix long exec stdout truncated at websocket frame boundaries

### DIFF
--- a/kubernetes/base/stream/ws_client.py
+++ b/kubernetes/base/stream/ws_client.py
@@ -197,8 +197,23 @@ class WSClient:
         """The same as write_channel with channel=0."""
         self.write_channel(STDIN_CHANNEL, data)
 
+    def _frames_immediately_available(self):
+        """Return True if at least one more frame is already waiting on
+        the socket and can be read without blocking."""
+        # Prefer poll over select for the same reasons as in update().
+        if hasattr(select, "poll"):
+            poll = select.poll()
+            poll.register(self.sock.sock, select.POLLIN)
+            r = poll.poll(0)
+            poll.unregister(self.sock.sock)
+        else:
+            r, _, _ = select.select((self.sock.sock, ), (), (), 0)
+        return bool(r)
+
     def update(self, timeout=0):
-        """Update channel buffers with at most one complete frame of input."""
+        """Update channel buffers with all complete frames of input that
+        are available, waiting at most `timeout` seconds for the first
+        one."""
         if not self.is_open():
             return
         if not self.sock.connected:
@@ -229,7 +244,7 @@ class WSClient:
             r, _, _ = select.select(
                 (self.sock.sock, ), (), (), timeout)
 
-        if r:
+        while r:
             op_code, frame = self.sock.recv_data_frame(True)
             if op_code == ABNF.OPCODE_CLOSE:
                 self._connected = False
@@ -263,6 +278,13 @@ class WSClient:
                             self._channels[channel] = data
                         else:
                             self._channels[channel] += data
+
+            # Output larger than the websocket frame size (e.g. long exec
+            # stdout) arrives as a sequence of frames. Consume every frame
+            # that is already available before returning, otherwise callers
+            # reading a channel after a single update() would see the
+            # output truncated at a frame boundary.
+            r = self._frames_immediately_available()
 
     def run_forever(self, timeout=None):
         """Wait till connection is closed or timeout reached. Buffer any input

--- a/kubernetes/base/stream/ws_client_test.py
+++ b/kubernetes/base/stream/ws_client_test.py
@@ -16,10 +16,11 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from . import ws_client as ws_client_module
-from .ws_client import get_websocket_url, WSClient, V5_CHANNEL_PROTOCOL, V4_CHANNEL_PROTOCOL, CLOSE_CHANNEL, STDIN_CHANNEL
+from .ws_client import get_websocket_url, WSClient, V5_CHANNEL_PROTOCOL, V4_CHANNEL_PROTOCOL, CLOSE_CHANNEL, STDIN_CHANNEL, STDOUT_CHANNEL
 from .ws_client import websocket_proxycare
 from kubernetes.client.configuration import Configuration
 import os
+import select
 import socket
 import threading
 import pytest
@@ -127,6 +128,139 @@ class WSClientTest(unittest.TestCase):
             assert dictval(connect_opts, 'http_no_proxy') == expect_noproxy
 
 
+class WSClientMultiFrameReadTest(unittest.TestCase):
+    """Tests that reads spanning multiple websocket frames are not
+    truncated at a frame boundary (issue #2226)"""
+
+    def setUp(self):
+        # Mock configuration to avoid real connections in WSClient.__init__
+        self.config_mock = MagicMock()
+        self.config_mock.assert_hostname = False
+        self.config_mock.api_key = {}
+        self.config_mock.proxy = None
+        self.config_mock.ssl_ca_cert = None
+        self.config_mock.cert_file = None
+        self.config_mock.key_file = None
+        self.config_mock.verify_ssl = True
+
+    def _make_client(self, mock_ws):
+        with patch.object(ws_client_module, 'create_websocket') as mock_create:
+            mock_create.return_value = mock_ws
+            return WSClient(self.config_mock, "wss://test", headers=None,
+                            capture_all=True)
+
+    def test_read_stdout_returns_all_available_frames(self):
+        """Verify a single peek/read returns output spanning several frames.
+
+        The server sends long exec stdout as a sequence of websocket
+        messages (32768 bytes each). Reading only one frame per update()
+        truncated the output at a frame boundary for callers using the
+        peek_stdout()/read_stdout() pattern."""
+        frame_payload = 32768
+        total = 70000
+        payload = b'x' * total
+
+        mock_ws = MagicMock()
+        mock_ws.subprotocol = V4_CHANNEL_PROTOCOL
+        mock_ws.connected = True
+        client = self._make_client(mock_ws)
+
+        server_sock, client_sock = socket.socketpair()
+        try:
+            # Make sure the whole simulated server output fits in the
+            # socket buffers so sendall() below cannot block.
+            client_sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF,
+                                   4 * frame_payload)
+            server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF,
+                                   4 * frame_payload)
+
+            ws = websocket.WebSocket()
+            ws.sock = client_sock
+            ws.connected = True
+            client.sock = ws
+
+            # The stdout messages (server frames are unmasked), followed by
+            # a close frame, just like an exec of `cat <long file>`.
+            frames = b''
+            for offset in range(0, total, frame_payload):
+                chunk = (bytes([STDOUT_CHANNEL])
+                         + payload[offset:offset + frame_payload])
+                frames += websocket.ABNF(
+                    1, 0, 0, 0, websocket.ABNF.OPCODE_BINARY, 0,
+                    chunk).format()
+            frames += websocket.ABNF(
+                1, 0, 0, 0, websocket.ABNF.OPCODE_CLOSE, 0,
+                b'\x03\xe8').format()
+            server_sock.sendall(frames)
+
+            out = ''
+            if client.peek_stdout(timeout=5):
+                out = client.read_stdout()
+
+            self.assertEqual(len(out), total)
+            # The close frame was consumed as well
+            self.assertFalse(client.is_open())
+        finally:
+            server_sock.close()
+            client_sock.close()
+
+    def test_update_consumes_all_immediately_available_frames(self):
+        """Verify update() drains every frame that is already readable"""
+        with patch('select.poll') as mock_poll, \
+             patch('select.select') as mock_select:
+            # The socket reports readable twice, then has no more data.
+            mock_poll.return_value.poll.side_effect = [
+                [(10, select.POLLIN)], [(10, select.POLLIN)], []]
+            mock_select.side_effect = [
+                ([10], [], []), ([10], [], []), ([], [], [])]
+
+            frame1 = MagicMock()
+            frame1.data = bytes([STDOUT_CHANNEL]) + b'first'
+            frame2 = MagicMock()
+            frame2.data = bytes([STDOUT_CHANNEL]) + b'second'
+
+            mock_ws = MagicMock()
+            mock_ws.subprotocol = V4_CHANNEL_PROTOCOL
+            mock_ws.connected = True
+            mock_ws.recv_data_frame.side_effect = [
+                (websocket.ABNF.OPCODE_BINARY, frame1),
+                (websocket.ABNF.OPCODE_BINARY, frame2)]
+
+            client = self._make_client(mock_ws)
+            client.update(timeout=0)
+
+            self.assertEqual(mock_ws.recv_data_frame.call_count, 2)
+            self.assertEqual(client._channels.get(STDOUT_CHANNEL),
+                             'firstsecond')
+
+    def test_update_stops_draining_on_close_frame(self):
+        """Verify the drain loop terminates when a close frame arrives"""
+        with patch('select.poll') as mock_poll, \
+             patch('select.select') as mock_select:
+            # The socket always reports readable.
+            mock_poll.return_value.poll.return_value = [(10, select.POLLIN)]
+            mock_select.return_value = ([10], [], [])
+
+            frame1 = MagicMock()
+            frame1.data = bytes([STDOUT_CHANNEL]) + b'output'
+            close_frame = MagicMock()
+            close_frame.data = b'\x03\xe8'
+
+            mock_ws = MagicMock()
+            mock_ws.subprotocol = V4_CHANNEL_PROTOCOL
+            mock_ws.connected = True
+            mock_ws.recv_data_frame.side_effect = [
+                (websocket.ABNF.OPCODE_BINARY, frame1),
+                (websocket.ABNF.OPCODE_CLOSE, close_frame)]
+
+            client = self._make_client(mock_ws)
+            client.update(timeout=0)
+
+            self.assertEqual(mock_ws.recv_data_frame.call_count, 2)
+            self.assertEqual(client._channels.get(STDOUT_CHANNEL), 'output')
+            self.assertFalse(client.is_open())
+
+
 class WSClientProtocolTest(unittest.TestCase):
     """Tests for WSClient V5 protocol handling"""
 
@@ -211,6 +345,7 @@ class WSClientProtocolTest(unittest.TestCase):
     def test_update_ignores_close_signal_v4(self):
         """Verify update treats 0xFF as regular data (or ignores signal interpretation) when v4"""
         with patch.object(ws_client_module, 'create_websocket') as mock_create, \
+            patch('select.poll') as mock_poll, \
             patch('select.select') as mock_select:
 
             mock_ws = MagicMock()
@@ -224,7 +359,11 @@ class WSClientProtocolTest(unittest.TestCase):
             mock_ws.recv_data_frame.return_value = (websocket.ABNF.OPCODE_BINARY, frame)
 
             mock_create.return_value = mock_ws
-            mock_select.return_value = ([mock_ws.sock], [], [])
+            # The frame is readable once, then there is no more data.
+            mock_poll.return_value.poll.side_effect = [
+                [(10, select.POLLIN)], []]
+            mock_select.side_effect = [
+                ([mock_ws.sock], [], []), ([], [], [])]
 
             client = WSClient(self.config_mock, "ws://test", headers=None, capture_all=True, binary=True) # binary=True to avoid decode errors
             client.update(timeout=0)

--- a/kubernetes/base/stream/ws_client_test.py
+++ b/kubernetes/base/stream/ws_client_test.py
@@ -161,7 +161,7 @@ class WSClientMultiFrameReadTest(unittest.TestCase):
         payload = b'x' * total
 
         mock_ws = MagicMock()
-        mock_ws.subprotocol = V4_CHANNEL_PROTOCOL
+        mock_ws.subprotocol = V5_CHANNEL_PROTOCOL
         mock_ws.connected = True
         client = self._make_client(mock_ws)
 
@@ -220,7 +220,7 @@ class WSClientMultiFrameReadTest(unittest.TestCase):
             frame2.data = bytes([STDOUT_CHANNEL]) + b'second'
 
             mock_ws = MagicMock()
-            mock_ws.subprotocol = V4_CHANNEL_PROTOCOL
+            mock_ws.subprotocol = V5_CHANNEL_PROTOCOL
             mock_ws.connected = True
             mock_ws.recv_data_frame.side_effect = [
                 (websocket.ABNF.OPCODE_BINARY, frame1),
@@ -247,7 +247,7 @@ class WSClientMultiFrameReadTest(unittest.TestCase):
             close_frame.data = b'\x03\xe8'
 
             mock_ws = MagicMock()
-            mock_ws.subprotocol = V4_CHANNEL_PROTOCOL
+            mock_ws.subprotocol = V5_CHANNEL_PROTOCOL
             mock_ws.connected = True
             mock_ws.recv_data_frame.side_effect = [
                 (websocket.ABNF.OPCODE_BINARY, frame1),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`WSClient.update()` consumed at most **one** websocket frame per call. The API server delivers long exec output as a sequence of websocket messages (32768 bytes each), so callers that read a channel after a single `update()` — most prominently the `peek_stdout()` / `read_stdout()` pattern used by Airflow's `pod_manager` when extracting XCom sidecar output — only ever saw the first frame and the output was truncated at exactly 32768 characters, producing errors like:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 16385 (char 16384)
```

This PR makes `update()` keep reading frames while more frames are already waiting on the socket (checked with a zero-timeout `poll()`/`select()`), so the channel buffers contain everything that has been received when `update()` returns. The drain loop still terminates on a close frame and never waits for data that has not arrived, so blocking behaviour and timeouts are unchanged. This mirrors the frame-drain loop that `PortForward._proxy()` in the same module already uses.

Reproduction (fails on master, passes with this PR): a server sends a 70000-byte stdout as three websocket messages plus a close frame; a single `peek_stdout()`/`read_stdout()` returns 32768 bytes on master and all 70000 bytes with this fix. This is added as a unit test, together with two mock-based tests asserting that `update()` drains all immediately-available frames and stops at a close frame.

Two hypotheses from the issue thread were ruled out while investigating:
- Continuation (`OPCODE_CONT`) frames are **not** the cause: `websocket-client` is created with the default `fire_cont_frame=False`, so `recv_data_frame()` reassembles fragmented messages internally and returns the complete payload (verified with a unit-level experiment).
- The truncation happens client-side, not server-side: the remaining frames are demonstrably sitting unread in the socket buffer.

#### Which issue(s) this PR fixes:

Fixes #2226

#### Special notes for your reviewer:

- **Relationship to #2375:** that issue is a second, independent defect in the same read path — `update()` can block in `poll()`/`select()` while decrypted frames are already buffered inside the `SSLSocket` (invisible to `poll()`). A separate PR addressing #2375 (successor of the stale-closed #2422) is being submitted alongside this one; the two changes touch different parts of `update()`, merge cleanly in either order (verified with a simulated merge; the combined test suite passes), and are deliberately kept orthogonal. Once both have landed, a trivial follow-up could extend `_frames_immediately_available()` to also consult `SSLSocket.pending()` so a single `update()` call drains SSL-buffered frames too.
- **Semantic change:** the docstring of `update()` previously promised "at most one complete frame". No caller in this repository (nor the Airflow usage that motivated the issue) depends on one-frame-per-call behaviour; `run_forever()`, `readline_channel()` and the peek/read helpers all only become more complete. The v5 `CLOSE_CHANNEL` signal handling is unchanged (it still returns after processing the signal frame).
- `test_update_ignores_close_signal_v4` previously relied on the real `select.poll()` observing an unrelated readable file descriptor while `recv_data_frame` was mocked to return the same frame forever; with the drain loop that combination would spin, so the test now mocks `poll()` deterministically (readable once, then empty).

Tested with `python -m pytest kubernetes/base/stream/ws_client_test.py -q`: 19 passed (the 3 new tests fail on master without the `ws_client.py` change).

#### Does this PR introduce a user-facing change?

```release-note
Fixed reading of long exec stdout/stderr being truncated at a websocket frame boundary (32768 characters): WSClient.update() now buffers all frames that have already been received instead of at most one per call.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

Sibling PR: #2650 (fixes #2375, same module — merge-compatible in either order, combined tests pass).

This change was developed with AI assistance (Claude Code); I have reviewed and tested it.
