### PR TITLE
Fix parameter name in ConfigMapLock.create docstring

### DIFF
--- a/kubernetes/base/leaderelection/resourcelock/configmaplock.py
+++ b/kubernetes/base/leaderelection/resourcelock/configmaplock.py
@@ -73,7 +73,7 @@ class ConfigMapLock:
 
     def create(self, name, namespace, election_record):
         """
-        :param electionRecord: Annotation string
+        :param election_record: Annotation string
         :param name: Name of the configmap object to be created
         :param namespace: Namespace in which the configmap object is to be created
         :return: 'True' if object is created else 'False' if failed


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

`ConfigMapLock.create` documented `:param electionRecord:`, but the parameter is named `election_record`:

```python
def create(self, name, namespace, election_record):
    """
    :param electionRecord: Annotation string
```

So the docstring described a parameter that does not exist on the method, while the real one was left undocumented. This corrects the name to match the signature.

The change is in `kubernetes/base/leaderelection/resourcelock/configmaplock.py`. Note `kubernetes/leaderelection` is a symlink into `kubernetes/base/`, so there is a single real file and no second copy to update.

One line. Documentation only — no behaviour change.

#### Which issue(s) this PR fixes:

None — found by comparing documented `:param` entries against actual function signatures.

#### Special notes for your reviewer:

The documented parameters on `create` now exactly match its signature (`name`, `namespace`, `election_record`). Nothing under `kubernetes/client/` was touched, so no generated code is affected, and no tests reference `leaderelection`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
