### PR TITLE
fix(client): allow ApiClient serialization with pickle

### DIFF
--- a/kubernetes/client/api_client.py
+++ b/kubernetes/client/api_client.py
@@ -922,3 +922,26 @@ class ApiClient:
         """
 
         return klass.from_dict(data)
+    
+    def __getstate__(self):
+        """Prepares the object state for pickling by removing unpicklable attributes."""
+        state = self.__dict__.copy()
+        # Supprime les attributs contenant des locks et connexions réseau
+        if 'rest_client' in state:
+            del state['rest_client']
+        if '_pool_lock' in state:
+            del state['_pool_lock']
+        if 'pool_manager' in state:
+            del state['pool_manager']
+        return state
+
+    def __setstate__(self, state):
+        """Restores the object state after unpickling."""
+        self.__dict__.update(state)
+        # Re-instancie le client REST et le lock après désérialisation
+        import threading
+        from kubernetes.client.rest import RESTClientObject
+        
+        self._pool_lock = threading.Lock()
+        if not hasattr(self, 'rest_client') or self.rest_client is None:
+            self.rest_client = RESTClientObject(self.configuration)

--- a/kubernetes/test/test_api_client.py
+++ b/kubernetes/test/test_api_client.py
@@ -41,6 +41,17 @@ class TestApiClient(unittest.TestCase):
                     client._ApiClient__deserialize(expected, response_type),
                     expected,
                 )
+                
+    def test_api_client_pickle(self):
+        import pickle
+        from kubernetes.client.api_client import ApiClient
+
+        client = ApiClient()
+        data = pickle.dumps(client)
+        restored = pickle.loads(data)
+
+        self.assertIsNotNone(restored)
+        self.assertIsInstance(restored, ApiClient)
 
     def test_rest_proxycare(self):
 


### PR DESCRIPTION
### Description
Resolves `PicklingError` when serializing `ApiClient` by implementing `__getstate__` and `__setstate__`. Unpicklable thread locks (`_pool_lock`), REST client objects (`rest_client`), and network pool managers are properly removed before serialization and re-initialized upon unpickling.

### Test Plan
Added `test_api_client_pickle` in `kubernetes/test/test_api_client.py` ensuring `pickle.dumps` and `pickle.loads` execute without errors. All unit tests in `kubernetes/test/test_api_client.py` passed (12/12).