### PR TITLE
Stop leading when onstarted_leading raises

### DIFF
--- a/kubernetes/base/leaderelection/leaderelection.py
+++ b/kubernetes/base/leaderelection/leaderelection.py
@@ -55,12 +55,23 @@ class LeaderElection:
             logger.info("{} successfully acquired lease".format(self.election_config.lock.identity))
 
             # Start leading and call OnStartedLeading()
-            threading.Thread(target=self.election_config.onstarted_leading, daemon=True).start()
+            leading_failed = threading.Event()
+            threading.Thread(target=self.run_onstarted_leading, args=(leading_failed,), daemon=True).start()
 
-            self.renew_loop()
+            self.renew_loop(leading_failed)
 
             # Failed to update lease, run OnStoppedLeading callback
             self.election_config.onstopped_leading()
+
+    def run_onstarted_leading(self, leading_failed):
+        # Run the callback in this thread, recording whether it raised. Without
+        # this the exception is swallowed by the worker thread and the lease keeps
+        # being renewed even though the work it protects is no longer running.
+        try:
+            self.election_config.onstarted_leading()
+        except Exception:
+            logger.exception("onstarted_leading raised an exception, stopping leading")
+            leading_failed.set()
 
     def acquire(self):
         # Follower
@@ -75,7 +86,7 @@ class LeaderElection:
 
             time.sleep(retry_period)
 
-    def renew_loop(self):
+    def renew_loop(self, leading_failed=None):
         # Leader
         logger.info("Leader has entered renew loop and will try to update lease continuously")
 
@@ -83,6 +94,11 @@ class LeaderElection:
         renew_deadline = self.election_config.renew_deadline * 1000
 
         while True:
+            # onstarted_leading raised, so stop renewing a lease that no longer
+            # protects anything and let run() call onstopped_leading.
+            if leading_failed is not None and leading_failed.is_set():
+                return
+
             timeout = int(time.time() * 1000) + renew_deadline
             succeeded = False
 

--- a/kubernetes/base/leaderelection/leaderelection_test.py
+++ b/kubernetes/base/leaderelection/leaderelection_test.py
@@ -20,6 +20,7 @@ from . import electionconfig
 import unittest
 import threading
 import json
+import sys
 import time
 import pytest
 from unittest.mock import patch
@@ -221,6 +222,32 @@ class LeaderElectionTest(unittest.TestCase):
         self.assertTrue(started.wait(1), "onstarted_leading callback did not run")
         self.assertIn("daemon", captured)
         self.assertTrue(captured["daemon"])
+
+    """Expected behavior: if onstarted_leading raises, the lease it protects is no
+    longer backed by any running work, so the candidate must stop renewing it and
+    run onstopped_leading. The lock below never refuses a renewal, so the renew
+    loop can only end because the callback failed."""
+    def test_stops_leading_when_onstarted_leading_raises(self):
+        stopped = threading.Event()
+
+        mock_lock = MockResourceLock("mock", "mock_namespace", "mock", thread_lock,
+                                     lambda: None, lambda: None, lambda: None, None)
+        mock_lock.renew_count_max = sys.maxsize
+
+        def on_started_leading():
+            raise RuntimeError("onstarted_leading failed")
+
+        config = electionconfig.Config(lock=mock_lock, lease_duration=2,
+                                       renew_deadline=1.5, retry_period=1.1,
+                                       onstarted_leading=on_started_leading,
+                                       onstopped_leading=stopped.set)
+
+        # Run in a daemon thread so a regression times out instead of hanging.
+        threading.Thread(target=leaderelection.LeaderElection(config).run,
+                         daemon=True).start()
+
+        self.assertTrue(stopped.wait(10),
+                        "onstopped_leading was not called after onstarted_leading raised")
 
     def assert_history(self, history, expected):
         self.assertIsNotNone(expected)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`onstarted_leading` is started on its own thread, so when it raises, the
exception is swallowed by that thread and the renew loop never learns about it.
The candidate keeps renewing its lease indefinitely even though the work the
lease is meant to protect has stopped, and `onstopped_leading` is never called.
Because the lease keeps being renewed, no other candidate can take over either.

This records the failure and checks it at the top of the renew loop, so the
candidate stops renewing and `run()` calls `onstopped_leading` — the same path
already taken when a renewal fails.

**Scope:** only the failure case reported in the issue changes. A callback that
returns normally behaves exactly as before, and none of the existing tests
needed to be modified.

Reproduced before fixing, with a lock that never refuses a renewal (so the only
thing that can end the leadership is the callback):

| | renewals after the callback died | `onstopped_leading` called |
|---|---|---|
| before | 8 (unbounded) | no |
| after | 1 | yes |

#### Which issue(s) this PR fixes:

Fixes #2075

#### Special notes for your reviewer:

- The new test uses a `MockResourceLock` whose `renew_count_max` is
  `sys.maxsize`, so the renew loop can only exit because the callback failed —
  it fails on `master` (times out) and passes with this change. It runs the
  election on a daemon thread so a regression times out rather than hanging CI.
- `renew_loop` keeps its old zero-argument form via a default of `None`, so any
  existing caller is unaffected.
- Only exceptions are caught; `BaseException` is deliberately not caught, so
  `KeyboardInterrupt` and `SystemExit` keep their current behaviour.
- Verified locally on macOS (Python 3.12): full suite minus e2e is **1484
  passed, 42 skipped, 0 failed**; the leaderelection suite goes 4 -> 5 passed.
  `flake8 --select=E9,F63,F7,F82` is clean, and `pycodestyle` reports exactly
  the same pre-existing findings before and after this change.

#### Does this PR introduce a user-facing change?

```release-note
Leader election now stops leading and calls `onstopped_leading` when the `onstarted_leading` callback raises, instead of renewing the lease indefinitely. The exception is logged via the `leaderelection` logger.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
