### PR TITLE
Add client-go-compatible Retry-After retries to generated clients

### DIFF
--- a/kubernetes/aio/client/configuration.py
+++ b/kubernetes/aio/client/configuration.py
@@ -355,6 +355,22 @@ conf = client.Configuration(
         self.retries = retries
         """Retry configuration
         """
+        self.client_go_retries = False
+        """Enable Kubernetes client-go-compatible retry semantics.
+
+           When enabled, GET and HEAD requests retry Retry-After responses.
+           The retry ceiling is read from ``retries`` when set; otherwise it
+           follows the client-go default of at most 10 retries.
+        """
+        self.client_go_retry_backoff = None
+        """Backoff for Kubernetes client-go-compatible retries.
+
+           If unset, client-go-compatible GET and HEAD retries use the
+           client-go default retry ceiling with no additional client-side
+           delay beyond Retry-After. When set, ``retries`` still overrides
+           the retry ceiling if it is not None.
+        """
+
         self.trace_configs = trace_configs
         """aiohttp.TraceConfig list forwarded to ClientSession for tracing.
         """

--- a/kubernetes/aio/client/rest.py
+++ b/kubernetes/aio/client/rest.py
@@ -21,6 +21,11 @@ from typing import Any, Dict, Optional, Union
 import aiohttp
 import aiohttp_retry
 
+from kubernetes.aio.utils.retry import (
+    is_retry_after_response,
+    on_retry_after_error,
+    retry_after_backoff,
+)
 from kubernetes.aio.client.exceptions import ApiException, ApiValueError
 
 RESTResponseType = aiohttp.ClientResponse
@@ -284,7 +289,16 @@ class RESTClientObject:
             self.pool_manager = self._create_pool_manager()
         pool_manager = self.pool_manager
 
-        if self._effective_retry_options is not None and method in ALLOW_RETRY_METHODS:
+        client_go_read_retries = (
+            method in ['GET', 'HEAD']
+            and getattr(self.configuration, 'client_go_retries', False)
+        )
+
+        if (
+            self._effective_retry_options is not None
+            and method in ALLOW_RETRY_METHODS
+            and not client_go_read_retries
+        ):
             if self.retry_client is None:
                 self.retry_client = aiohttp_retry.RetryClient(
                     client_session=self.pool_manager,
@@ -292,6 +306,38 @@ class RESTClientObject:
                 )
             pool_manager = self.retry_client
 
-        r = await pool_manager.request(**args)
+        async def read_request(check_retry_status=False):
+            response = await self.pool_manager.request(**args)
+            if check_retry_status:
+                self._raise_retry_after_response(response)
+            return response
+
+        if client_go_read_retries:
+            backoff = retry_after_backoff(
+                getattr(self.configuration, 'retries', None),
+                getattr(self.configuration, 'client_go_retry_backoff', None),
+            )
+            r = await on_retry_after_error(
+                backoff, self._is_read_retryable, lambda: read_request(True))
+        else:
+            r = await pool_manager.request(**args)
 
         return RESTResponse(r)
+
+    @classmethod
+    def _is_read_retryable(cls, error):
+        return is_retry_after_response(error)
+
+    @staticmethod
+    def _retry_after_error(response):
+        error = ApiException(status=response.status, reason=response.reason)
+        error.headers = response.headers
+        return error
+
+    @classmethod
+    def _raise_retry_after_response(cls, response):
+        error = cls._retry_after_error(response)
+        if not is_retry_after_response(error):
+            return
+        response.release()
+        raise error

--- a/kubernetes/aio/test/test_generated_api.py
+++ b/kubernetes/aio/test/test_generated_api.py
@@ -46,6 +46,8 @@ class GeneratedAsyncApiTest(IsolatedAsyncioTestCase):
             'items': [],
         }
         self.response_status = 200
+        self.response_headers = {}
+        self.responses = None
         app = web.Application()
         app.router.add_route('*', '/{path:.*}', self._handle_request)
         self.runner = web.AppRunner(app)
@@ -91,7 +93,17 @@ class GeneratedAsyncApiTest(IsolatedAsyncioTestCase):
             }).encode() + b'\n')
             await response.write_eof()
             return response
-        return web.json_response(self.response, status=self.response_status)
+        if self.responses is not None:
+            index = len(self.requests) - 1
+            response, status, headers = self.responses[
+                min(index, len(self.responses) - 1)
+            ]
+            return web.json_response(response, status=status, headers=headers)
+        return web.json_response(
+            self.response,
+            status=self.response_status,
+            headers=self.response_headers,
+        )
 
     async def test_bearer_alias_supports_synchronous_token_refresh(self):
         self.configuration.api_key['authorization'] = 'expired-token'
@@ -122,6 +134,20 @@ class GeneratedAsyncApiTest(IsolatedAsyncioTestCase):
             'Bearer refreshed-token',
             self.requests[-1][0].headers['Authorization'],
         )
+
+    async def test_client_go_retry_retries_get_retry_after_response(self):
+        self.configuration.client_go_retries = True
+        self.configuration.retries = 1
+        self.responses = [
+            ({'message': 'retry later'}, 429, {'Retry-After': '0'}),
+            (self.response, 200, {}),
+        ]
+
+        namespaces = await CoreV1Api(self.api_client).list_namespace()
+
+        self.assertEqual([], namespaces.items)
+        self.assertEqual(2, len(self.requests))
+        self.assertIsNone(self.api_client.rest_client.retry_client)
 
     async def test_delete_job_accepts_job_and_status_responses(self):
         responses = (

--- a/kubernetes/aio/utils/create_from_yaml.py
+++ b/kubernetes/aio/utils/create_from_yaml.py
@@ -18,8 +18,6 @@ from os import path
 
 import yaml
 
-from kubernetes.aio import client
-
 
 async def create_from_yaml(
         k8s_client,
@@ -115,6 +113,8 @@ async def create_from_dict(
         processing of the request.
         Valid values are: - All: all dry run stages will be processed
     """
+    from kubernetes.aio import client
+
     api_exceptions = []
     k8s_objects = []
 
@@ -156,6 +156,8 @@ async def create_from_yaml_single_item(
         verbose=False,
         namespace="default",
         **kwargs):
+    from kubernetes.aio import client
+
     group, _, version = yml_object["apiVersion"].partition("/")
     if version == "":
         version = group

--- a/kubernetes/aio/utils/retry_test.py
+++ b/kubernetes/aio/utils/retry_test.py
@@ -20,6 +20,7 @@ from kubernetes.aio.utils.retry import (
     is_too_many_requests,
     on_error,
     on_retry_after_error,
+    retry_after_max_retries,
     retry_after_seconds,
     retry_on_conflict,
 )
@@ -33,6 +34,12 @@ class FakeError(Exception):
         self.headers = headers or {}
 
 
+class RetryOptions:
+
+    def __init__(self, attempts):
+        self.attempts = attempts
+
+
 class AioRetryTest(unittest.IsolatedAsyncioTestCase):
 
     def test_default_retry_matches_client_go(self):
@@ -40,6 +47,10 @@ class AioRetryTest(unittest.IsolatedAsyncioTestCase):
             DEFAULT_RETRY,
             Backoff(steps=5, duration=0.01, factor=1.0, jitter=0.1),
         )
+
+    def test_retry_after_backoff_uses_aio_retry_attempts(self):
+        self.assertEqual(retry_after_max_retries(RetryOptions(attempts=3)), 2)
+        self.assertEqual(retry_after_max_retries(RetryOptions(attempts=1)), 0)
 
     def test_retry_after_seconds_parses_delay_seconds(self):
         error = FakeError(429, {"Retry-After": "7"})

--- a/kubernetes/base/retry.py
+++ b/kubernetes/base/retry.py
@@ -77,7 +77,8 @@ def retry_after_backoff(
     ``None``, it is interpreted as the retry ceiling and overrides
     ``backoff.steps``. ``False`` and ``0`` disable retries by returning a
     single-attempt backoff. Integer values and urllib3-style Retry objects with
-    a ``total`` value are treated as the retry ceiling.
+    a ``total`` value are treated as retry ceilings. aiohttp-retry-style
+    options with an ``attempts`` value are treated as request attempt ceilings.
     """
 
     if backoff is None:
@@ -106,13 +107,22 @@ def retry_after_max_retries(retries: Any = None) -> int:
     if isinstance(retries, int):
         return max(0, retries)
 
-    total = getattr(retries, "total", None)
-    if total is False:
+    if hasattr(retries, "total"):
+        total = getattr(retries, "total", None)
+        if total is False:
+            return 0
+        if total is True or total is None:
+            return 10
+        if isinstance(total, int):
+            return max(0, total)
+
+    attempts = getattr(retries, "attempts", None)
+    if attempts is False:
         return 0
-    if total is True or total is None:
+    if attempts is True:
         return 10
-    if isinstance(total, int):
-        return max(0, total)
+    if isinstance(attempts, int):
+        return max(0, attempts - 1)
     return 10
 
 

--- a/kubernetes/client/configuration.py
+++ b/kubernetes/client/configuration.py
@@ -357,6 +357,22 @@ conf = client.Configuration(
         self.retries = retries
         """Retry configuration
         """
+        self.client_go_retries = False
+        """Enable Kubernetes client-go-compatible retry semantics.
+
+           When enabled, GET and HEAD requests retry Retry-After responses.
+           The retry ceiling is read from ``retries`` when set; otherwise it
+           follows the client-go default of at most 10 retries.
+        """
+        self.client_go_retry_backoff = None
+        """Backoff for Kubernetes client-go-compatible retries.
+
+           If unset, client-go-compatible GET and HEAD retries use the
+           client-go default retry ceiling with no additional client-side
+           delay beyond Retry-After. When set, ``retries`` still overrides
+           the retry ceiling if it is not None.
+        """
+
         # Enable client side validation
         self.client_side_validation = client_side_validation
 

--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -20,7 +20,13 @@ import ssl
 from urllib.parse import urlparse
 
 import urllib3
+from urllib3.util.retry import Retry
 
+from kubernetes.utils.retry import (
+    is_retry_after_response,
+    on_retry_after_error,
+    retry_after_backoff,
+)
 from kubernetes.client.exceptions import ApiException, ApiValueError
 
 SUPPORTED_SOCKS_PROXIES = {"socks5", "socks5h", "socks4", "socks4a"}
@@ -105,6 +111,8 @@ class RESTResponse(io.IOBase):
 class RESTClientObject:
 
     def __init__(self, configuration) -> None:
+        self.configuration = configuration
+
         # urllib3.PoolManager will pass all kw parameters to connectionpool
         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/poolmanager.py#L75  # noqa: E501
         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680  # noqa: E501
@@ -217,6 +225,32 @@ class RESTClientObject:
                     read=_request_timeout[1]
                 )
 
+        client_go_read_retries = (
+            method in ['GET', 'HEAD']
+            and getattr(self.configuration, 'client_go_retries', False)
+        )
+        read_retries = None
+        if client_go_read_retries:
+            read_retries = self._urllib3_retries_without_status(
+                getattr(self.configuration, 'retries', None))
+
+        def read_request(check_retry_status=False):
+            kwargs = {}
+            if read_retries is not None:
+                kwargs['retries'] = read_retries
+            response = self.pool_manager.request(
+                method,
+                url,
+                fields={},
+                timeout=timeout,
+                headers=headers,
+                preload_content=False,
+                **kwargs
+            )
+            if check_retry_status:
+                self._raise_retry_after_response(response)
+            return response
+
         try:
             # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
             if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
@@ -310,16 +344,67 @@ class RESTClientObject:
                     raise ApiException(status=0, reason=msg)
             # For `GET`, `HEAD`
             else:
-                r = self.pool_manager.request(
-                    method,
-                    url,
-                    fields={},
-                    timeout=timeout,
-                    headers=headers,
-                    preload_content=False
-                )
+                if client_go_read_retries:
+                    backoff = retry_after_backoff(
+                        getattr(self.configuration, 'retries', None),
+                        getattr(self.configuration, 'client_go_retry_backoff', None),
+                    )
+                    r = on_retry_after_error(
+                        backoff, self._is_read_retryable,
+                        lambda: read_request(True))
+                else:
+                    r = read_request()
         except urllib3.exceptions.SSLError as e:
             msg = "\n".join([type(e).__name__, str(e)])
             raise ApiException(status=0, reason=msg)
 
         return RESTResponse(r)
+
+    @classmethod
+    def _is_read_retryable(cls, error):
+        return is_retry_after_response(error)
+
+    @staticmethod
+    def _retry_after_error(response):
+        error = ApiException(status=response.status, reason=response.reason)
+        error.headers = response.getheaders()
+        return error
+
+    @classmethod
+    def _raise_retry_after_response(cls, response):
+        error = cls._retry_after_error(response)
+        if not is_retry_after_response(error):
+            return
+        cls._read_and_close_retry_response(response)
+        raise error
+
+    @staticmethod
+    def _read_and_close_retry_response(response):
+        try:
+            try:
+                content_length = int(response.getheaders().get(
+                    'Content-Length', '-1'))
+            except (TypeError, ValueError):
+                content_length = -1
+            if content_length <= 2 << 10:
+                response.read(2 << 10)
+        finally:
+            response.close()
+
+    @staticmethod
+    def _urllib3_retries_without_status(retries):
+        if retries is False:
+            return False
+        if retries is None:
+            retries = Retry.DEFAULT
+        elif retries is True:
+            retries = Retry.DEFAULT
+        elif isinstance(retries, int):
+            retries = Retry.from_int(retries)
+        if isinstance(retries, Retry):
+            return retries.new(
+                status=0,
+                status_forcelist=(),
+                respect_retry_after_header=False,
+            )
+        return retries

--- a/kubernetes/test/test_api_client.py
+++ b/kubernetes/test/test_api_client.py
@@ -8,6 +8,7 @@ import weakref
 import kubernetes
 from kubernetes.aio.client.configuration import Configuration as AsyncConfiguration
 from kubernetes.client.configuration import Configuration
+from kubernetes.client.rest import RESTClientObject
 import urllib3
 
 
@@ -66,6 +67,24 @@ class TestApiClient(unittest.TestCase):
             # test
             client = kubernetes.client.ApiClient(configuration=config)
             self.assertEqual( expected_pool, type(client.rest_client.pool_manager) )
+
+    def test_client_go_read_retries_do_not_override_write_retries(self):
+        config = Configuration(proxy='', no_proxy='', retries=urllib3.Retry(total=2))
+        config.client_go_retries = True
+        rest_client = RESTClientObject(config)
+        rest_client.pool_manager = mock.Mock()
+        rest_client.pool_manager.request.return_value = urllib3.HTTPResponse(
+            body=b'{}', status=200, reason='OK',
+        )
+
+        rest_client.request(
+            'PATCH',
+            'http://example.test/api/v1/namespaces/default/configmaps/sample',
+            headers={'Content-Type': 'application/json'},
+            body={},
+        )
+
+        self.assertNotIn('retries', rest_client.pool_manager.request.call_args.kwargs)
 
 
 class TestConfigurationAuthSettings(unittest.TestCase):

--- a/kubernetes/test/test_generated_api.py
+++ b/kubernetes/test/test_generated_api.py
@@ -80,10 +80,25 @@ class _RecordingHandler(BaseHTTPRequestHandler):
         self._respond()
 
     def _respond(self):
+        request_index = self.server.request_count
+        self.server.request_count += 1
         response = self.server.response_body
-        self.send_response(self.server.response_status)
+        response_bodies = getattr(self.server, 'response_bodies', None)
+        if response_bodies is not None:
+            response = response_bodies[min(request_index, len(response_bodies) - 1)]
+        status = self.server.response_status
+        response_statuses = getattr(self.server, 'response_statuses', None)
+        if response_statuses is not None:
+            status = response_statuses[min(request_index, len(response_statuses) - 1)]
+        response_headers = self.server.response_headers
+        response_header_sets = getattr(self.server, 'response_header_sets', None)
+        if response_header_sets is not None:
+            response_headers = response_header_sets[min(request_index, len(response_header_sets) - 1)]
+        self.send_response(status)
         self.send_header('Content-Type', 'application/json')
         self.send_header('Content-Length', str(len(response)))
+        for key, value in response_headers.items():
+            self.send_header(key, value)
         self.end_headers()
         self.wfile.write(response)
 
@@ -386,6 +401,8 @@ class GeneratedApiTest(unittest.TestCase):
             ('127.0.0.1', 0), _RecordingHandler)
         self.server.response_body = b'{}'
         self.server.response_status = 200
+        self.server.response_headers = {}
+        self.server.request_count = 0
         self.thread = threading.Thread(target=self.server.serve_forever)
         self.thread.start()
         self.api_client = ApiClient(Configuration(
@@ -410,6 +427,24 @@ class GeneratedApiTest(unittest.TestCase):
             '/api/v1/namespaces?continue=next-page',
             self.server.request_path,
         )
+
+    def test_client_go_retry_retries_get_retry_after_response(self):
+        self.api_client.configuration.client_go_retries = True
+        self.api_client.configuration.retries = 1
+        self.server.response_statuses = [429, 200]
+        self.server.response_bodies = [
+            b'{"message": "retry later"}',
+            b'{"items": []}',
+        ]
+        self.server.response_header_sets = [
+            {'Retry-After': '0'},
+            {},
+        ]
+
+        namespaces = CoreV1Api(self.api_client).list_namespace()
+
+        self.assertEqual([], namespaces.items)
+        self.assertEqual(2, self.server.request_count)
 
     def test_deferred_api_validation_rejects_invalid_first_call(self):
         with self.assertRaises(ValidationError) as raised:

--- a/kubernetes/test/test_metrics.py
+++ b/kubernetes/test/test_metrics.py
@@ -22,7 +22,7 @@ class TestMetrics(unittest.TestCase):
     def setUp(self):
         self.mock_api_client = MagicMock(spec=client.ApiClient)
 
-    @patch('kubernetes.utils.metrics.CustomObjectsApi')
+    @patch('kubernetes.client.api.custom_objects_api.CustomObjectsApi')
     def test_get_nodes_metrics_success(self, mock_custom_api_class):
         """Test successful retrieval of node metrics"""
         mock_api_instance = MagicMock()
@@ -54,7 +54,7 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(len(result['items']), 1)
         self.assertEqual(result['items'][0]['metadata']['name'], 'node1')
 
-    @patch('kubernetes.utils.metrics.CustomObjectsApi')
+    @patch('kubernetes.client.api.custom_objects_api.CustomObjectsApi')
     def test_get_pods_metrics_success(self, mock_custom_api_class):
         """Test successful retrieval of pod metrics"""
         mock_api_instance = MagicMock()
@@ -91,7 +91,7 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(result, expected_response)
         self.assertEqual(len(result['items']), 1)
 
-    @patch('kubernetes.utils.metrics.CustomObjectsApi')
+    @patch('kubernetes.client.api.custom_objects_api.CustomObjectsApi')
     def test_get_pods_metrics_with_label_selector(self, mock_custom_api_class):
         """Test pod metrics retrieval with label selector"""
         mock_api_instance = MagicMock()

--- a/kubernetes/utils/create_from_yaml.py
+++ b/kubernetes/utils/create_from_yaml.py
@@ -17,8 +17,6 @@ import os
 import re
 
 import yaml
-from kubernetes import client
-from kubernetes.dynamic.client import DynamicClient
 
 UPPER_FOLLOWED_BY_LOWER_RE = re.compile("(.)([A-Z][a-z]+)")
 LOWER_OR_NUM_FOLLOWED_BY_UPPER_RE = re.compile("([a-z0-9])([A-Z])")
@@ -207,6 +205,8 @@ def create_from_dict(
         FailToCreateError which holds list of `client.rest.ApiException`
         instances for each object that failed to create.
     """
+    from kubernetes import client
+
     # If it is a list type, will need to iterate its items
     api_exceptions = []
     k8s_objects = []
@@ -255,6 +255,8 @@ def create_from_yaml_single_item(
 ):
     kind = yml_object["kind"]
     if apply is True:
+        from kubernetes.dynamic.client import DynamicClient
+
         apply_client = DynamicClient(k8s_client).resources.get(
             api_version=yml_object["apiVersion"], kind=kind
         )
@@ -267,6 +269,8 @@ def create_from_yaml_single_item(
                 msg += " status='{0}'".format(str(resp.status))
             print(msg)
         return resp
+    from kubernetes import client
+
     group, _, version = yml_object["apiVersion"].partition("/")
     if version == "":
         version = group

--- a/kubernetes/utils/metrics.py
+++ b/kubernetes/utils/metrics.py
@@ -19,11 +19,14 @@ Provides helpers for fetching and processing resource usage data from the
 metrics.k8s.io API endpoint, enabling monitoring and autoscaling workflows.
 """
 
-from kubernetes.client.api.custom_objects_api import CustomObjectsApi
-
-
 METRICS_API_GROUP = "metrics.k8s.io"
 METRICS_API_VERSION = "v1beta1"
+
+
+def _custom_objects_api(api_client):
+    from kubernetes.client.api.custom_objects_api import CustomObjectsApi
+
+    return CustomObjectsApi(api_client)
 
 
 def get_nodes_metrics(api_client):
@@ -67,7 +70,7 @@ def get_nodes_metrics(api_client):
         ...     mem = node['usage']['memory']
         ...     print(f"Node {name}: CPU={cpu}, Memory={mem}")
     """
-    api = CustomObjectsApi(api_client)
+    api = _custom_objects_api(api_client)
     return api.list_cluster_custom_object(
         group=METRICS_API_GROUP,
         version=METRICS_API_VERSION,
@@ -137,7 +140,7 @@ def get_pods_metrics(api_client, namespace, label_selector=None):
     if not namespace:
         raise ValueError("namespace parameter is required and cannot be empty")
     
-    api = CustomObjectsApi(api_client)
+    api = _custom_objects_api(api_client)
     
     kwargs = {
         "group": METRICS_API_GROUP,

--- a/kubernetes/utils/retry_test.py
+++ b/kubernetes/utils/retry_test.py
@@ -39,6 +39,12 @@ def api_exception(status, headers=None):
     return error
 
 
+class RetryOptions:
+
+    def __init__(self, attempts):
+        self.attempts = attempts
+
+
 class RetryTest(unittest.TestCase):
 
     def test_default_backoffs_match_client_go(self):
@@ -61,6 +67,8 @@ class RetryTest(unittest.TestCase):
         self.assertEqual(retry_after_max_retries(0), 0)
         self.assertEqual(retry_after_max_retries(3), 3)
         self.assertEqual(retry_after_max_retries(Retry(total=2)), 2)
+        self.assertEqual(retry_after_max_retries(RetryOptions(attempts=3)), 2)
+        self.assertEqual(retry_after_max_retries(RetryOptions(attempts=1)), 0)
         self.assertEqual(retry_after_backoff(3).steps, 4)
 
     def test_retry_after_backoff_can_be_configured(self):

--- a/scripts/client_go_retry_asyncio_patch.diff
+++ b/scripts/client_go_retry_asyncio_patch.diff
@@ -1,0 +1,79 @@
+diff --git a/kubernetes/aio/client/configuration.py b/kubernetes/aio/client/configuration.py
+index 8a6da82ec..c26bac633 100644
+--- a/kubernetes/aio/client/configuration.py
++++ b/kubernetes/aio/client/configuration.py
+@@ -357,0 +358,16 @@ conf = client.Configuration(
++        self.client_go_retries = False
++        """Enable Kubernetes client-go-compatible retry semantics.
++
++           When enabled, GET and HEAD requests retry Retry-After responses.
++           The retry ceiling is read from ``retries`` when set; otherwise it
++           follows the client-go default of at most 10 retries.
++        """
++        self.client_go_retry_backoff = None
++        """Backoff for Kubernetes client-go-compatible retries.
++
++           If unset, client-go-compatible GET and HEAD retries use the
++           client-go default retry ceiling with no additional client-side
++           delay beyond Retry-After. When set, ``retries`` still overrides
++           the retry ceiling if it is not None.
++        """
++
+diff --git a/kubernetes/aio/client/rest.py b/kubernetes/aio/client/rest.py
+index 087f52a43..d8bf6ab90 100644
+--- a/kubernetes/aio/client/rest.py
++++ b/kubernetes/aio/client/rest.py
+@@ -23,0 +24,5 @@ import aiohttp_retry
++from kubernetes.aio.utils.retry import (
++    is_retry_after_response,
++    on_retry_after_error,
++    retry_after_backoff,
++)
+@@ -287 +292,10 @@ class RESTClientObject:
+-        if self._effective_retry_options is not None and method in ALLOW_RETRY_METHODS:
++        client_go_read_retries = (
++            method in ['GET', 'HEAD']
++            and getattr(self.configuration, 'client_go_retries', False)
++        )
++
++        if (
++            self._effective_retry_options is not None
++            and method in ALLOW_RETRY_METHODS
++            and not client_go_read_retries
++        ):
+@@ -295 +309,15 @@ class RESTClientObject:
+-        r = await pool_manager.request(**args)
++        async def read_request(check_retry_status=False):
++            response = await self.pool_manager.request(**args)
++            if check_retry_status:
++                self._raise_retry_after_response(response)
++            return response
++
++        if client_go_read_retries:
++            backoff = retry_after_backoff(
++                getattr(self.configuration, 'retries', None),
++                getattr(self.configuration, 'client_go_retry_backoff', None),
++            )
++            r = await on_retry_after_error(
++                backoff, self._is_read_retryable, lambda: read_request(True))
++        else:
++            r = await pool_manager.request(**args)
+@@ -297,0 +326,18 @@ class RESTClientObject:
++
++    @classmethod
++    def _is_read_retryable(cls, error):
++        return is_retry_after_response(error)
++
++    @staticmethod
++    def _retry_after_error(response):
++        error = ApiException(status=response.status, reason=response.reason)
++        error.headers = response.headers
++        return error
++
++    @classmethod
++    def _raise_retry_after_response(cls, response):
++        error = cls._retry_after_error(response)
++        if not is_retry_after_response(error):
++            return
++        response.release()
++        raise error

--- a/scripts/client_go_retry_patch.diff
+++ b/scripts/client_go_retry_patch.diff
@@ -1,0 +1,132 @@
+diff --git a/kubernetes/client/configuration.py b/kubernetes/client/configuration.py
+index 5e150b408..3ef976444 100644
+--- a/kubernetes/client/configuration.py
++++ b/kubernetes/client/configuration.py
+@@ -359,0 +360,16 @@ conf = client.Configuration(
++        self.client_go_retries = False
++        """Enable Kubernetes client-go-compatible retry semantics.
++
++           When enabled, GET and HEAD requests retry Retry-After responses.
++           The retry ceiling is read from ``retries`` when set; otherwise it
++           follows the client-go default of at most 10 retries.
++        """
++        self.client_go_retry_backoff = None
++        """Backoff for Kubernetes client-go-compatible retries.
++
++           If unset, client-go-compatible GET and HEAD retries use the
++           client-go default retry ceiling with no additional client-side
++           delay beyond Retry-After. When set, ``retries`` still overrides
++           the retry ceiling if it is not None.
++        """
++
+diff --git a/kubernetes/client/rest.py b/kubernetes/client/rest.py
+index 9fca6dca3..a5fb08c7a 100644
+--- a/kubernetes/client/rest.py
++++ b/kubernetes/client/rest.py
+@@ -22,0 +23 @@ import urllib3
++from urllib3.util.retry import Retry
+@@ -23,0 +25,5 @@ import urllib3
++from kubernetes.utils.retry import (
++    is_retry_after_response,
++    on_retry_after_error,
++    retry_after_backoff,
++)
+@@ -107,0 +114,2 @@ class RESTClientObject:
++        self.configuration = configuration
++
+@@ -219,0 +228,26 @@ class RESTClientObject:
++        client_go_read_retries = (
++            method in ['GET', 'HEAD']
++            and getattr(self.configuration, 'client_go_retries', False)
++        )
++        read_retries = None
++        if client_go_read_retries:
++            read_retries = self._urllib3_retries_without_status(
++                getattr(self.configuration, 'retries', None))
++
++        def read_request(check_retry_status=False):
++            kwargs = {}
++            if read_retries is not None:
++                kwargs['retries'] = read_retries
++            response = self.pool_manager.request(
++                method,
++                url,
++                fields={},
++                timeout=timeout,
++                headers=headers,
++                preload_content=False,
++                **kwargs
++            )
++            if check_retry_status:
++                self._raise_retry_after_response(response)
++            return response
++
+@@ -313,8 +347,10 @@ class RESTClientObject:
+-                r = self.pool_manager.request(
+-                    method,
+-                    url,
+-                    fields={},
+-                    timeout=timeout,
+-                    headers=headers,
+-                    preload_content=False
+-                )
++                if client_go_read_retries:
++                    backoff = retry_after_backoff(
++                        getattr(self.configuration, 'retries', None),
++                        getattr(self.configuration, 'client_go_retry_backoff', None),
++                    )
++                    r = on_retry_after_error(
++                        backoff, self._is_read_retryable,
++                        lambda: read_request(True))
++                else:
++                    r = read_request()
+@@ -325,0 +362,49 @@ class RESTClientObject:
++
++    @classmethod
++    def _is_read_retryable(cls, error):
++        return is_retry_after_response(error)
++
++    @staticmethod
++    def _retry_after_error(response):
++        error = ApiException(status=response.status, reason=response.reason)
++        error.headers = response.getheaders()
++        return error
++
++    @classmethod
++    def _raise_retry_after_response(cls, response):
++        error = cls._retry_after_error(response)
++        if not is_retry_after_response(error):
++            return
++        cls._read_and_close_retry_response(response)
++        raise error
++
++    @staticmethod
++    def _read_and_close_retry_response(response):
++        try:
++            try:
++                content_length = int(response.getheaders().get(
++                    'Content-Length', '-1'))
++            except (TypeError, ValueError):
++                content_length = -1
++            if content_length <= 2 << 10:
++                response.read(2 << 10)
++        finally:
++            response.close()
++
++    @staticmethod
++    def _urllib3_retries_without_status(retries):
++        if retries is False:
++            return False
++        if retries is None:
++            retries = Retry.DEFAULT
++        elif retries is True:
++            retries = Retry.DEFAULT
++        elif isinstance(retries, int):
++            retries = Retry.from_int(retries)
++        if isinstance(retries, Retry):
++            return retries.new(
++                status=0,
++                status_forcelist=(),
++                respect_retry_after_header=False,
++            )
++        return retries

--- a/scripts/update-client-asyncio.sh
+++ b/scripts/update-client-asyncio.sh
@@ -58,6 +58,9 @@ echo ">>> Running python generator from the gen repo"
 "${GEN_ROOT}/openapi/python-aio.sh" "${CLIENT_ROOT}" "${SETTING_FILE}"
 mv "${CLIENT_ROOT}/swagger.json" "${SCRIPT_ROOT}/swagger.json"
 
+echo ">>> restoring Kubernetes client-go retry integration..."
+git apply --unidiff-zero "${SCRIPT_ROOT}/client_go_retry_asyncio_patch.diff"
+
 echo ">>> updating version information..."
 sed -i'' "s/^CLIENT_VERSION = .*/CLIENT_VERSION = \\\"${CLIENT_VERSION}\\\"/" "${SCRIPT_ROOT}/../setup-asyncio.py"
 sed -i'' "s/^__version__ = .*/__version__ = \\\"${CLIENT_VERSION}\\\"/" "${CLIENT_ROOT}/__init__.py"

--- a/scripts/update-client.sh
+++ b/scripts/update-client.sh
@@ -62,6 +62,9 @@ mv "${CLIENT_ROOT}/swagger.json" "${SCRIPT_ROOT}/swagger.json"
 echo ">>> restoring Kubernetes patch media-type selection..."
 git apply "${SCRIPT_ROOT}/rest_client_patch.diff"
 
+echo ">>> restoring Kubernetes client-go retry integration..."
+git apply --unidiff-zero "${SCRIPT_ROOT}/client_go_retry_patch.diff"
+
 echo ">>> updating version information..."
 sed -i'' "s/^CLIENT_VERSION = .*/CLIENT_VERSION = \\\"${CLIENT_VERSION}\\\"/" "${SCRIPT_ROOT}/../setup.py"
 sed -i'' "s/^__version__ = .*/__version__ = \\\"${CLIENT_VERSION}\\\"/" "${CLIENT_ROOT}/__init__.py"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Wires the retry helpers from kubernetes-client/python#2634 into the generated sync and asyncio REST clients via repo-local post-generation patches, matching the Java-style approach instead of carrying Kubernetes-specific behavior in kubernetes-client/gen.

The generated clients gain opt-in `client_go_retries` support for `GET` and `HEAD` Retry-After responses. The retry ceiling follows `configuration.retries` when set and otherwise uses the client-go default. Sync uses urllib3 for normal retries and disables urllib3 status retries only for the client-go read wrapper; asyncio uses its async helper directly for that same read path.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
Added opt-in client-go-compatible Retry-After retries for generated Python and asyncio GET/HEAD requests.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

#### Testing

- `git diff --check`
- `git apply --unidiff-zero --reverse --check scripts/client_go_retry_patch.diff`
- `git apply --unidiff-zero --reverse --check scripts/client_go_retry_asyncio_patch.diff`
- `git apply --unidiff-zero --check scripts/client_go_retry_patch.diff` against a fresh `origin/master` worktree
- `git apply --unidiff-zero --check scripts/client_go_retry_asyncio_patch.diff` against a fresh `origin/master` worktree
- `python3 -m py_compile ...` for the changed retry/rest/config/test modules
- `uv run --with-requirements requirements.txt --with-requirements requirements-asyncio.txt python -c "import kubernetes.client.rest; import kubernetes.aio.client.rest"`
- `uv run --with-requirements requirements.txt --with-requirements requirements-asyncio.txt python -m unittest -q ...` for the new targeted retry tests