### PR TITLE
Read proxy-url from kubeconfig cluster

### DIFF
--- a/kubernetes/base/config/kube_config.py
+++ b/kubernetes/base/config/kube_config.py
@@ -523,6 +523,8 @@ class KubeConfigLoader:
             self.verify_ssl = not self._cluster['insecure-skip-tls-verify']
         if 'tls-server-name' in self._cluster:
             self.tls_server_name = self._cluster['tls-server-name']
+        if 'proxy-url' in self._cluster:
+            self.proxy = self._cluster['proxy-url']
 
     def _set_config(self, client_configuration):
         if 'token' in self.__dict__:
@@ -534,7 +536,8 @@ class KubeConfigLoader:
                 self._set_config(client_configuration)
             client_configuration.refresh_api_key_hook = _refresh_api_key
         # copy these keys directly from self to configuration object
-        keys = ['host', 'ssl_ca_cert', 'cert_file', 'key_file', 'verify_ssl','tls_server_name']
+        keys = ['host', 'ssl_ca_cert', 'cert_file', 'key_file', 'verify_ssl',
+                'tls_server_name', 'proxy']
         for key in keys:
             if key in self.__dict__:
                 setattr(client_configuration, key, getattr(self, key))

--- a/kubernetes/base/config/kube_config_test.py
+++ b/kubernetes/base/config/kube_config_test.py
@@ -102,6 +102,7 @@ TEST_CLIENT_KEY_BASE64 = _base64(TEST_CLIENT_KEY)
 TEST_CLIENT_CERT = "client-cert"
 TEST_CLIENT_CERT_BASE64 = _base64(TEST_CLIENT_CERT)
 TEST_TLS_SERVER_NAME = "kubernetes.io"
+TEST_PROXY_URL = "http://proxy.example.com:3128"
 
 TEST_OIDC_TOKEN = "test-oidc-token"
 TEST_OIDC_INFO = "{\"name\": \"test\"}"
@@ -580,6 +581,13 @@ class TestKubeConfigLoader(BaseTestCase):
                     "user": "ssl"
                 }
             },
+            {
+                "name": "proxy_cluster_context",
+                "context": {
+                    "cluster": "proxy_cluster",
+                    "user": "simple_token"
+                }
+            },
         ],
         "clusters": [
             {
@@ -630,6 +638,13 @@ class TestKubeConfigLoader(BaseTestCase):
                         TEST_CERTIFICATE_AUTH_BASE64,
                     "insecure-skip-tls-verify": False,
                     "tls-server-name": TEST_TLS_SERVER_NAME,
+                }
+            },
+            {
+                "name": "proxy_cluster",
+                "cluster": {
+                    "server": TEST_HOST,
+                    "proxy-url": TEST_PROXY_URL,
                 }
             },
         ],
@@ -1136,6 +1151,18 @@ class TestKubeConfigLoader(BaseTestCase):
             active_context="tls-server-name").load_and_set(actual)
         self.assertEqual(expected, actual)
 
+    def test_proxy_url_from_cluster(self):
+        expected = FakeConfig(
+            host=TEST_HOST,
+            token=BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
+            proxy=TEST_PROXY_URL,
+        )
+        actual = FakeConfig()
+        KubeConfigLoader(
+            config_dict=self.TEST_KUBE_CONFIG,
+            active_context="proxy_cluster_context").load_and_set(actual)
+        self.assertEqual(expected, actual)
+
     def test_list_contexts(self):
         loader = KubeConfigLoader(
             config_dict=self.TEST_KUBE_CONFIG,
@@ -1284,6 +1311,14 @@ class TestKubeConfigLoader(BaseTestCase):
         self.assertEqual(TEST_HOST, client.configuration.host)
         self.assertEqual(BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
                          client.configuration.api_key['BearerToken'])
+
+    def test_new_client_from_config_proxy(self):
+        config_file = self._create_temp_file(
+            yaml.safe_dump(self.TEST_KUBE_CONFIG))
+        client = new_client_from_config(
+            config_file=config_file, context="proxy_cluster_context")
+        self.assertEqual(TEST_HOST, client.configuration.host)
+        self.assertEqual(TEST_PROXY_URL, client.configuration.proxy)
 
     def test_new_client_from_config_dict(self):
         client = new_client_from_config_dict(


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

`load_kube_config()` ignored the `proxy-url` field of a kubeconfig `cluster`
entry, so `Configuration.proxy` stayed `None` and requests went direct,
bypassing the configured proxy. There was no warning — the field was parsed
and dropped.

Two changes in `kubernetes/base/config/kube_config.py`:

- `_load_cluster_info()` reads `proxy-url` into `self.proxy`
- `_set_config()` copies `proxy` to the client configuration

This mirrors `kubernetes/aio/config/kube_config.py`, which already does both,
and brings the sync client in line with `kubectl`/client-go.

The `keys` list in `_set_config()` is wrapped across two lines; it was 94
characters and missing a space after `'verify_ssl',`.

#### Which issue(s) this PR fixes:

Fixes #2679

#### Special notes for your reviewer:

Scope was agreed with @yliaog in #2679: loader only, no generated files
touched. The `HTTPS_PROXY`/`HTTP_PROXY` problem described in that issue is
deliberately left out, since it would land in the generated
`kubernetes/client/configuration.py` — happy to file it separately.

Tests are ported from the existing async suite:

- `test_proxy_url_from_cluster` — loader level, mirrors the async test of the
  same name
- `test_new_client_from_config_proxy` — through the public entry point

Both fail without the change (verified by reverting `kube_config.py` alone and
re-running); the full sync config suite is 77 passed.

Also verified end to end against a kind cluster whose API server was reachable
only through a proxy: the control-plane container's DNS name is not resolvable
from the host, and kubeadm already puts that name in the apiserver cert SANs,
so TLS validates normally without `insecure-skip-tls-verify`. Before the
change the call failed with a name-resolution error and `Configuration.proxy`
was `None`; after it, `proxy` is set, the request succeeds, and the proxy logs
`CONNECT proxytest-control-plane:6443`.

#### Does this PR introduce a user-facing change?

```release-note
`load_kube_config()` now honors the `proxy-url` field of a kubeconfig cluster entry and sets `Configuration.proxy` from it.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [kubeconfig v1 Cluster reference]: https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/#Cluster
```
