### PR TITLE
restored test case test_watch_with_deserialize_param added in PR http…

### DIFF
--- a/kubernetes/base/watch/watch_test.py
+++ b/kubernetes/base/watch/watch_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import time
 from types import SimpleNamespace
@@ -613,45 +614,49 @@ class WatchTests(unittest.TestCase):
             self.api.delete_namespaced_pod(name=pod_name, namespace=self.namespace)
             self.api.delete_namespaced_pod.assert_called_once_with(name=pod_name, namespace=self.namespace)
 
-#    Comment out the test below, it does not work currently.
-#    def test_watch_with_deserialize_param(self):
-#        """test watch.stream() deserialize param"""
-#        # prepare test data
-#        test_json = '{"type": "ADDED", "object": {"metadata": {"name": "test1", "resourceVersion": "1"}, "spec": {}, "status": {}}}'
-#        fake_resp = Mock()
-#        fake_resp.close = Mock()
-#        fake_resp.release_conn = Mock()
-#        fake_resp.stream = Mock(return_value=[test_json + '\n'])
-#    
-#        fake_api = Mock()
-#        fake_api.get_namespaces = Mock(return_value=fake_resp)
-#        fake_api.get_namespaces.__doc__ = ':rtype: V1NamespaceList'
-#    
-#        # test case with deserialize=True
-#        w = Watch()
-#        for e in w.stream(fake_api.get_namespaces, deserialize=True):
-#            self.assertEqual("ADDED", e['type'])
-#            # Verify that the object is deserialized correctly
-#            self.assertTrue(hasattr(e['object'], 'metadata'))
-#            self.assertEqual("test1", e['object'].metadata.name)
-#            self.assertEqual("1", e['object'].metadata.resource_version)
-#            # Verify that the original object is saved
-#            self.assertEqual(json.loads(test_json)['object'], e['raw_object'])
-#    
-#        # test case with deserialize=False
-#        w = Watch()
-#        for e in w.stream(fake_api.get_namespaces, deserialize=False):
-#            self.assertEqual("ADDED", e['type'])
-#            # The validation object remains in the original dictionary format
-#            self.assertIsInstance(e['object'], dict)
-#            self.assertEqual("test1", e['object']['metadata']['name'])
-#            self.assertEqual("1", e['object']['metadata']['resourceVersion'])
-#    
-#        # verify the api is called twice
-#        fake_api.get_namespaces.assert_has_calls([
-#            call(_preload_content=False, watch=True),
-#            call(_preload_content=False, watch=True)
-#        ])
+    def test_watch_with_deserialize_param(self):
+        """test watch.stream() deserialize param"""
+        # prepare test data
+        test_json = '{"type": "ADDED", "object": {"metadata": {"name": "test1", "resourceVersion": "1"}, "spec": {}, "status": {}}}'
+        fake_resp = Mock()
+        fake_resp.close = Mock()
+        fake_resp.release_conn = Mock()
+        fake_resp.stream = Mock(return_value=[test_json + '\n'])
+    
+        fake_api = Mock()
+        fake_api.get_namespaces = Mock(return_value=fake_resp)
+        fake_api.get_namespaces.__doc__ = ':rtype: V1NamespaceList'
+    
+        # test case with deserialize=True
+        w = Watch()
+        count = 0
+        for e in w.stream(fake_api.get_namespaces, deserialize=True):
+            self.assertEqual("ADDED", e['type'])
+            # Verify that the object is deserialized correctly
+            self.assertTrue(hasattr(e['object'], 'metadata'))
+            self.assertEqual("test1", e['object'].metadata.name)
+            self.assertEqual("1", e['object'].metadata.resource_version)
+            # Verify that the original object is saved
+            self.assertEqual(json.loads(test_json)['object'], e['raw_object'])
+            count += 1
+            if count == 1:
+                w.stop()
+        self.assertEqual(1, count)
+    
+        # test case with deserialize=False
+        w = Watch()
+        for e in w.stream(fake_api.get_namespaces, deserialize=False):
+            self.assertEqual("ADDED", e['type'])
+            # The validation object remains in the original dictionary format
+            self.assertIsInstance(e['object'], dict)
+            self.assertEqual("test1", e['object']['metadata']['name'])
+            self.assertEqual("1", e['object']['metadata']['resourceVersion'])
+    
+        # verify the api is called twice
+        fake_api.get_namespaces.assert_has_calls([
+            call(_preload_content=False, watch=True),
+            call(_preload_content=False, watch=True)
+        ])
     
 
 if __name__ == '__main__':


### PR DESCRIPTION
…s://github.com/kubernetes-client/python/pull/2406

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
restored the test case added in PR: https://github.com/kubernetes-client/python/pull/2406, it was disabled as it did not work. now the test has been fixed. it can be reenabled.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
