### PR TITLE
Use setuptools license_expression for the license metadata

### DIFF
--- a/setup-asyncio.py
+++ b/setup-asyncio.py
@@ -39,7 +39,7 @@ setup(
     description="Kubernetes asynchronous python client",
     author_email="",
     author="Kubernetes",
-    license="Apache-2.0",
+    license_expression="Apache-2.0",
     url="https://github.com/kubernetes-client/kubernetes/aio",
     keywords=["Swagger", "OpenAPI", "Kubernetes"],
     install_requires=REQUIRES,

--- a/setup-release.py
+++ b/setup-release.py
@@ -60,7 +60,7 @@ setup(
     description="Kubernetes python client",
     author_email="",
     author="Kubernetes",
-    license="Apache-2.0",
+    license_expression="Apache-2.0",
     url="https://github.com/kubernetes-client/python",
     keywords=["Swagger", "OpenAPI", "Kubernetes"],
     install_requires=REQUIRES+REQUIRES_ASYNCIO,

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     description="Kubernetes python client",
     author_email="",
     author="Kubernetes",
-    license="Apache-2.0",
+    license_expression="Apache-2.0",
     url="https://github.com/kubernetes-client/python",
     keywords=["Swagger", "OpenAPI", "Kubernetes"],
     install_requires=REQUIRES,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Follow-up to #2687, as requested there.

#2687 set the license to the SPDX identifier `Apache-2.0`, but a plain `license=`
keyword lands in the legacy free-text `License` field. setuptools'
`license_expression=` keyword produces the PEP 639 `License-Expression` field
instead, so that is what the three setup scripts now use.

Metadata built with setuptools 84.0.0:

    before:  License: Apache-2.0
    after:   License-Expression: Apache-2.0

Checked all three scripts, and the distribution names are unchanged:

    setup.py           Name: kubernetes        License-Expression: Apache-2.0
    setup-release.py   Name: kubernetes        License-Expression: Apache-2.0
    setup-asyncio.py   Name: kubernetes.aio    License-Expression: Apache-2.0

`License-File: LICENSE` is still there, and the legacy `License` field is gone.
`pip install -e .`, which is what `tox` does via `usedevelop = True`, still works.

#### Which issue(s) this PR fixes:

Follow-up to #2687, no separate issue.

#### Special notes for your reviewer:

`license_expression=` needs setuptools 77 or newer. Older versions ignore it with a
warning rather than failing, so an old build environment gets the same metadata it
gets today.

An earlier version of this PR added a `pyproject.toml` with `[project] license`.
That worked, but `[project] name` cannot be `dynamic`, so it renamed the
`setup-asyncio.py` build from `kubernetes.aio` to `kubernetes`. The keyword route
you asked for avoids that entirely and is three lines instead of a new file.

#### Does this PR introduce a user-facing change?

```release-note
Package metadata now declares the license using the PEP 639 `License-Expression` field.
```
