### PR TITLE
Fix the broken docs tox environment

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[build_sphinx]
-source-dir = doc/source
-build-dir = doc/build
-all_files = 1
-
-[upload_sphinx]
-upload-dir = doc/build/html

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-   py3{6,7,8,9}
-   py3{6,7,8,9}-functional
+   py3{10,11,12,13,14}
+   py3{10,11,12,13,14}-functional
 
 [testenv]
 passenv = TOXENV,CI,TRAVIS,TRAVIS_*
@@ -20,8 +20,12 @@ setenv =
    coverage: _TOX_COVERAGE_RUN=--cov=kubernetes/watch --cov=kubernetes/config
 
 [testenv:docs]
+allowlist_externals = make
+deps =
+   {[testenv]deps}
+   -r{toxinidir}/doc/requirements-docs.txt
 commands =
-   python setup.py build_sphinx
+   make -C doc html
 
 [testenv:update-pycodestyle]
 commands =


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

`tox -e docs` cannot run. It calls `python setup.py build_sphinx`, and that command
came from `sphinx.setup_command`, which Sphinx removed in 7.0. `test-requirements.txt`
pins `sphinx>=8.1.3`, so on a current checkout:

    $ python setup.py build_sphinx
    error: invalid command 'build_sphinx'

Fixing the command alone is not enough. `doc/source/conf.py` imports `recommonmark`
and lists it as an extension, and `recommonmark` appears in none of the four
requirements files the tox env already installs - it is only in
`doc/requirements-docs.txt`, which the env never pulls in. So the environment would
still have failed while loading `conf.py`.

This PR points the env at the build `doc/README.md` documents (`make html`, which is
`sphinx-apidoc` then `sphinx-build`) and adds `doc/requirements-docs.txt` to its deps.
After the change:

    docs: OK (13.89 seconds)
    congratulations :)

Two related bits of tidying that belong to the same story:

- `setup.cfg` contained `[build_sphinx]` and `[upload_sphinx]` and nothing else. Both
  are settings for the command Sphinx removed, so the file goes with them. The only
  other `setup.cfg` references in the tree are to the generated `kubernetes/setup.cfg`,
  which is a flake8 config and is untouched.
- `envlist` still named `py3{6,7,8,9}`. `setup.py` sets `python_requires='>=3.10'` and
  CI tests 3.10 through 3.14, so all four named environments are below the supported
  floor.

#### Which issue(s) this PR fixes:

No open issue - I hit this while looking at the packaging config in #2687 and #2688.
Happy to file one first if you would prefer that.

#### Special notes for your reviewer:

I verified the docs toolchain itself is healthy under Sphinx 8.1.3 - `sphinx-build`
loads `conf.py` with `recommonmark` and `sphinx_markdown_tables` and reports
`build succeeded`, and `sphinx-apidoc` generates all 1,810 module pages. I did not
run the full 1,800-module render to completion; that build is memory-hungry and my
machine ran out of RAM part way through writing HTML. Everything this PR claims is
about the tox environment resolving and invoking the right command, which is what
the `docs: OK` above shows.

Independent of #2688 - different branch, no shared files.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
